### PR TITLE
test: add Playwright E2E tests

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -40,6 +40,17 @@ jobs:
         run: npm test -- --run 2>&1 | tee /tmp/frontend-test-output.txt
         continue-on-error: true
 
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+        continue-on-error: true
+
+      - name: Run Playwright E2E tests
+        id: e2e-tests
+        working-directory: frontend
+        run: npx playwright test 2>&1 | tee /tmp/e2e-test-output.txt
+        continue-on-error: true
+
       - name: Install backend dependencies
         working-directory: backend
         run: |
@@ -70,6 +81,7 @@ jobs:
         with:
           script: |
             const frontend = '${{ steps.frontend-tests.outcome }}';
+            const e2e = '${{ steps.e2e-tests.outcome }}';
             const backend = '${{ steps.backend-tests.outcome }}';
             const cdk = '${{ steps.cdk-tests.outcome }}';
             const icon = (s) => s === 'success' ? '✅' : s === 'failure' ? '❌' : '⚠️';
@@ -77,6 +89,7 @@ jobs:
             const body = `## 🧪 Test Results\n\n` +
               `| Suite | Status |\n|-------|--------|\n` +
               `| Frontend | ${icon(frontend)} ${frontend} |\n` +
+              `| E2E (Playwright) | ${icon(e2e)} ${e2e} |\n` +
               `| Backend | ${icon(backend)} ${backend} |\n` +
               `| CDK | ${icon(cdk)} ${cdk} |\n`;
 
@@ -95,10 +108,11 @@ jobs:
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           FRONTEND="${{ steps.frontend-tests.outcome }}"
+          E2E="${{ steps.e2e-tests.outcome }}"
           BACKEND="${{ steps.backend-tests.outcome }}"
           CDK="${{ steps.cdk-tests.outcome }}"
 
-          MESSAGE="🔍 <b>PR Review Needed</b>: #${PR_NUMBER} — ${PR_TITLE}%0ABy: ${PR_AUTHOR}%0ATests: Frontend=${FRONTEND} Backend=${BACKEND} CDK=${CDK}%0A<a href=\"${PR_URL}\">Review PR</a>"
+          MESSAGE="🔍 <b>PR Review Needed</b>: #${PR_NUMBER} — ${PR_TITLE}%0ABy: ${PR_AUTHOR}%0ATests: Frontend=${FRONTEND} E2E=${E2E} Backend=${BACKEND} CDK=${CDK}%0A<a href=\"${PR_URL}\">Review PR</a>"
 
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ cdk.out/
 .venv/
 *.pyc
 .DS_Store
+test-results/
+playwright-report/

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "./fixtures/auth";
+import { setupAuthenticatedSession } from "./fixtures/auth";
+
+test.describe("Dashboard (authenticated)", () => {
+  test("shows welcome message when authenticated", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/");
+    await expect(
+      authenticatedPage.getByText(/welcome to runmaprepeat/i)
+    ).toBeVisible();
+  });
+
+  test("shows sign out button when authenticated", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/");
+    await expect(
+      authenticatedPage.getByRole("button", { name: /sign out/i })
+    ).toBeVisible();
+  });
+
+  test("shows placeholder text about runs", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/");
+    await expect(
+      authenticatedPage.getByText(/your runs will appear here/i)
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -1,0 +1,110 @@
+import { test as base, type Page } from "@playwright/test";
+
+/**
+ * Mock the Amplify auth module so tests work without real Cognito.
+ * Call this before navigating to any page.
+ */
+export async function mockAuthModule(
+  page: Page,
+  options: { authenticated: boolean; email?: string; userId?: string } = {
+    authenticated: false,
+  }
+) {
+  await page.addInitScript(
+    ({ authenticated, email, userId }) => {
+      // Mock @aws-amplify/auth at the window level so the app picks it up
+      (window as Record<string, unknown>).__mockAuth = {
+        authenticated,
+        email: email ?? "test@example.com",
+        userId: userId ?? "test-user-id",
+      };
+    },
+    {
+      authenticated: options.authenticated,
+      email: options.email,
+      userId: options.userId,
+    }
+  );
+
+  // Intercept the Amplify auth module imports by mocking the network requests
+  // and overriding module behavior via page.route for any Cognito API calls
+  await page.route("**/cognito-idp.*", (route) => {
+    const mockAuth = options.authenticated
+      ? {
+          AuthenticationResult: {
+            AccessToken: "mock-access-token",
+            IdToken: "mock-id-token",
+            RefreshToken: "mock-refresh-token",
+          },
+        }
+      : null;
+
+    if (mockAuth) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/x-amz-json-1.1",
+        body: JSON.stringify(mockAuth),
+      });
+    }
+    return route.fulfill({
+      status: 400,
+      contentType: "application/x-amz-json-1.1",
+      body: JSON.stringify({
+        __type: "NotAuthorizedException",
+        message: "Incorrect username or password.",
+      }),
+    });
+  });
+}
+
+/**
+ * Setup an authenticated session by mocking Amplify's internal storage.
+ * This makes getCurrentUser() and fetchUserAttributes() resolve with mock data.
+ */
+export async function setupAuthenticatedSession(
+  page: Page,
+  options: { email?: string; userId?: string } = {}
+) {
+  const email = options.email ?? "test@example.com";
+  const userId = options.userId ?? "test-user-id";
+
+  await page.addInitScript(
+    ({ email, userId }) => {
+      // Mock Amplify's localStorage-based auth state
+      const storageKey = "CognitoIdentityServiceProvider";
+      const clientId = "mock-client-id";
+      const lastAuthUser = `${storageKey}.${clientId}.LastAuthUser`;
+      const idTokenKey = `${storageKey}.${clientId}.${email}.idToken`;
+      const accessTokenKey = `${storageKey}.${clientId}.${email}.accessToken`;
+
+      // Create a minimal JWT-like token with user claims
+      const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+      const payload = btoa(
+        JSON.stringify({
+          sub: userId,
+          email: email,
+          email_verified: true,
+          token_use: "id",
+        })
+      );
+      const mockToken = `${header}.${payload}.mock-signature`;
+
+      localStorage.setItem(lastAuthUser, email);
+      localStorage.setItem(idTokenKey, mockToken);
+      localStorage.setItem(accessTokenKey, mockToken);
+    },
+    { email, userId }
+  );
+
+  await mockAuthModule(page, { authenticated: true, email, userId });
+}
+
+/** Extended test fixture with authenticated page helper */
+export const test = base.extend<{ authenticatedPage: Page }>({
+  authenticatedPage: async ({ page }, use) => {
+    await setupAuthenticatedSession(page);
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/frontend/e2e/login.spec.ts
+++ b/frontend/e2e/login.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+import { mockAuthModule } from "./fixtures/auth";
+
+test.describe("Login Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthModule(page, { authenticated: false });
+  });
+
+  test("page loads and shows RunMapRepeat title", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("heading", { name: "RunMapRepeat" })).toBeVisible();
+  });
+
+  test("shows email and password input fields", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Password")).toBeVisible();
+  });
+
+  test("shows sign in button", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  });
+
+  test("sign in button is disabled while submitting", async ({ page }) => {
+    // Mock Cognito to delay the response so we can observe the disabled state
+    await page.route("**/cognito-idp.*", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.fulfill({
+        status: 400,
+        contentType: "application/x-amz-json-1.1",
+        body: JSON.stringify({
+          __type: "NotAuthorizedException",
+          message: "Incorrect username or password.",
+        }),
+      });
+    });
+
+    await page.goto("/login");
+    await page.getByLabel("Email").fill("user@example.com");
+    await page.getByLabel("Password").fill("wrong-password");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page.getByRole("button", { name: "Signing in..." })).toBeDisabled();
+  });
+
+  test("shows error message on invalid credentials", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByLabel("Email").fill("user@example.com");
+    await page.getByLabel("Password").fill("wrong-password");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page.getByText(/incorrect|invalid|error/i)).toBeVisible();
+  });
+
+  test("empty form submission shows validation (required fields)", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // HTML5 required attribute prevents submission — check fields are invalid
+    const emailInput = page.getByLabel("Email");
+    const passwordInput = page.getByLabel("Password");
+
+    await expect(emailInput).toHaveAttribute("required", "");
+    await expect(passwordInput).toHaveAttribute("required", "");
+  });
+});

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import { mockAuthModule } from "./fixtures/auth";
+
+test.describe("Navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthModule(page, { authenticated: false });
+  });
+
+  test("unauthenticated user is redirected to /login", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("visiting / without auth redirects to /login", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: "RunMapRepeat" })).toBeVisible();
+  });
+
+  test("login page is accessible at /login", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByRole("heading", { name: "RunMapRepeat" })).toBeVisible();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "npx playwright test",
+    "test:e2e:ui": "npx playwright test --ui"
   },
   "dependencies": {
     "@aws-amplify/auth": "^6.0.0",
@@ -26,6 +28,7 @@
     "jsdom": "^23.0.0",
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
-    "vitest": "^1.0.0"
+    "vitest": "^1.0.0",
+    "@playwright/test": "^1.42.0"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "./test-results",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [["html", { outputFolder: "playwright-report" }]],
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
Adds Playwright end-to-end tests covering the login flow, navigation guards, and dashboard.

## Tests Added (12 E2E)

**Login Page (6):**
- Page loads and shows RunMapRepeat title
- Shows email and password input fields
- Shows sign in button
- Sign in button disabled while submitting
- Shows error on invalid credentials
- Empty form shows required field validation

**Navigation (3):**
- Unauthenticated user redirected to /login
- Visiting / without auth redirects to /login
- Login page accessible at /login

**Dashboard — mocked auth (3):**
- Shows welcome message when authenticated
- Shows sign out button
- Shows placeholder text about runs

## Test Infrastructure
- `frontend/e2e/fixtures/auth.ts` — Auth mocking helpers (no real Cognito needed)
- `frontend/playwright.config.ts` — Chromium, auto-starts Vite dev server
- CI workflow updated to run Playwright in PR checks

## Total Test Count: 24 (12 unit/CDK + 12 E2E)