### PR TITLE
feat: add structured audio tracking to runs

### DIFF
--- a/backend/handlers/runs.py
+++ b/backend/handlers/runs.py
@@ -109,7 +109,7 @@ def _create_run(user_id: str, event: dict[str, Any]) -> dict[str, Any]:
         "updatedAt": now,
     }
 
-    for field in ("title", "route", "distanceMeters", "durationSeconds", "elevationGainMeters", "notes"):
+    for field in ("title", "route", "distanceMeters", "durationSeconds", "elevationGainMeters", "notes", "audio"):
         if field in body:
             run_data[field] = body[field]
 
@@ -158,7 +158,7 @@ def _update_run(user_id: str, run_id: str | None, event: dict[str, Any]) -> dict
         return _error(400, "; ".join(errors))
 
     update_data: dict[str, Any] = {"updatedAt": datetime.now(timezone.utc).isoformat()}
-    for field in ("status", "runDate", "title", "route", "distanceMeters", "durationSeconds", "elevationGainMeters", "notes"):
+    for field in ("status", "runDate", "title", "route", "distanceMeters", "durationSeconds", "elevationGainMeters", "notes", "audio"):
         if field in body:
             update_data[field] = body[field]
 

--- a/backend/handlers/utils/validation.py
+++ b/backend/handlers/utils/validation.py
@@ -73,6 +73,46 @@ def validate_run(body: dict[str, Any]) -> list[str]:
         if not isinstance(body["elevationGainMeters"], (int, float)) or body["elevationGainMeters"] < 0:
             errors.append("elevationGainMeters must be a non-negative number")
 
+    if "audio" in body:
+        errors.extend(validate_audio(body["audio"]))
+
+    return errors
+
+
+_AUDIO_TYPES = ("music", "podcast")
+_MUSIC_SUBTYPES = ("artist", "playlist")
+_ARTIST_FORMATS = ("album", "mix")
+
+
+def validate_audio(audio: Any) -> list[str]:
+    """Validate the audio field on a run. Returns list of error messages."""
+    errors: list[str] = []
+
+    if not isinstance(audio, dict):
+        return ["audio must be an object"]
+
+    audio_type = audio.get("type")
+    if audio_type not in _AUDIO_TYPES:
+        errors.append(f"audio.type must be one of: {', '.join(_AUDIO_TYPES)}")
+        return errors
+
+    name = audio.get("name")
+    if not isinstance(name, str) or not name.strip():
+        errors.append("audio.name is required and must be a non-empty string")
+
+    if "detail" in audio:
+        if not isinstance(audio["detail"], str):
+            errors.append("audio.detail must be a string")
+
+    if audio_type == "music":
+        subtype = audio.get("subtype")
+        if subtype not in _MUSIC_SUBTYPES:
+            errors.append(f"audio.subtype must be one of: {', '.join(_MUSIC_SUBTYPES)}")
+        elif subtype == "artist":
+            fmt = audio.get("format")
+            if fmt not in _ARTIST_FORMATS:
+                errors.append(f"audio.format must be one of: {', '.join(_ARTIST_FORMATS)}")
+
     return errors
 
 

--- a/backend/tests/test_runs.py
+++ b/backend/tests/test_runs.py
@@ -164,3 +164,118 @@ def test_options_returns_200() -> None:
     event = _make_event("OPTIONS")
     response = handler(event, None)
     assert response["statusCode"] == 200
+
+
+@patch("handlers.runs.get_profile")
+@patch("handlers.runs.create_run")
+def test_create_run_with_audio_music_artist_album(mock_create: object, mock_profile: object) -> None:
+    mock_profile.return_value = {"weightKg": 70}
+    mock_create.side_effect = lambda uid, rid, data: {"runId": rid, **data}
+    event = _make_event(
+        "POST",
+        "/runs",
+        body={
+            "status": "completed",
+            "runDate": "2024-01-15T08:00:00Z",
+            "distanceMeters": 5000,
+            "durationSeconds": 1800,
+            "audio": {
+                "type": "music",
+                "subtype": "artist",
+                "format": "album",
+                "name": "Dua Lipa",
+                "detail": "Future Nostalgia",
+            },
+        },
+    )
+    response = handler(event, None)
+    assert response["statusCode"] == 201
+    body = json.loads(response["body"])
+    assert body["audio"]["type"] == "music"
+    assert body["audio"]["name"] == "Dua Lipa"
+
+
+@patch("handlers.runs.get_profile")
+@patch("handlers.runs.create_run")
+def test_create_run_with_audio_podcast(mock_create: object, mock_profile: object) -> None:
+    mock_profile.return_value = {"weightKg": 70}
+    mock_create.side_effect = lambda uid, rid, data: {"runId": rid, **data}
+    event = _make_event(
+        "POST",
+        "/runs",
+        body={
+            "status": "completed",
+            "runDate": "2024-01-15T08:00:00Z",
+            "distanceMeters": 3000,
+            "durationSeconds": 1200,
+            "audio": {
+                "type": "podcast",
+                "name": "Huberman Lab",
+                "detail": "Ep. 234",
+            },
+        },
+    )
+    response = handler(event, None)
+    assert response["statusCode"] == 201
+    body = json.loads(response["body"])
+    assert body["audio"]["type"] == "podcast"
+
+
+def test_create_run_with_invalid_audio_type() -> None:
+    event = _make_event(
+        "POST",
+        "/runs",
+        body={
+            "status": "completed",
+            "runDate": "2024-01-15T08:00:00Z",
+            "audio": {"type": "audiobook", "name": "Something"},
+        },
+    )
+    response = handler(event, None)
+    assert response["statusCode"] == 400
+    assert "audio.type" in json.loads(response["body"])["error"]
+
+
+def test_create_run_with_invalid_audio_missing_name() -> None:
+    event = _make_event(
+        "POST",
+        "/runs",
+        body={
+            "status": "completed",
+            "runDate": "2024-01-15T08:00:00Z",
+            "audio": {"type": "music", "subtype": "playlist"},
+        },
+    )
+    response = handler(event, None)
+    assert response["statusCode"] == 400
+    assert "audio.name" in json.loads(response["body"])["error"]
+
+
+def test_create_run_with_invalid_music_subtype() -> None:
+    event = _make_event(
+        "POST",
+        "/runs",
+        body={
+            "status": "completed",
+            "runDate": "2024-01-15T08:00:00Z",
+            "audio": {"type": "music", "subtype": "genre", "name": "Rock"},
+        },
+    )
+    response = handler(event, None)
+    assert response["statusCode"] == 400
+    assert "audio.subtype" in json.loads(response["body"])["error"]
+
+
+def test_create_run_with_invalid_artist_format() -> None:
+    event = _make_event(
+        "POST",
+        "/runs",
+        body={
+            "status": "completed",
+            "runDate": "2024-01-15T08:00:00Z",
+            "audio": {"type": "music", "subtype": "artist", "format": "single", "name": "Drake"},
+        },
+    )
+    response = handler(event, None)
+    assert response["statusCode"] == 400
+    assert "audio.format" in json.loads(response["body"])["error"]


### PR DESCRIPTION
Adds optional `audio` field to run records so users can log what they were listening to.

### Audio types
- **Music → Artist → Album** (e.g. Dua Lipa — Future Nostalgia)
- **Music → Artist → Mix** (e.g. Eminem — shuffled)
- **Music → Playlist** (e.g. Spotify Running Hits)
- **Podcast** (e.g. Huberman Lab — Ep. 234)

### Changes
- `validation.py` — new `validate_audio()` with full type/subtype/format validation
- `runs.py` — `audio` added to allowed fields in create + update
- 6 new tests (37/37 passing)

No DB schema change needed (DynamoDB is schemaless).