### PR TITLE
feat: add backend CI/CD pipeline (test + cdk deploy)

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -3,6 +3,7 @@ import aws_cdk as cdk
 
 from stacks.api_stack import ApiStack
 from stacks.auth_stack import AuthStack
+from stacks.backend_pipeline_stack import BackendPipelineStack
 from stacks.data_stack import DataStack
 from stacks.frontend_stack import FrontendStack
 from stacks.pipeline_stack import PipelineStack
@@ -30,5 +31,7 @@ PipelineStack(
     distribution_id="E2E3A3QH11PGOS",
     env=env,
 )
+
+BackendPipelineStack(app, "RunMapRepeat-Backend-Pipeline", env=env)
 
 app.synth()

--- a/infra/stacks/backend_pipeline_stack.py
+++ b/infra/stacks/backend_pipeline_stack.py
@@ -1,0 +1,152 @@
+"""CDK stack for the backend CI/CD pipeline."""
+
+from aws_cdk import (
+    Stack,
+    aws_codebuild as codebuild,
+    aws_codepipeline as codepipeline,
+    aws_codepipeline_actions as actions,
+    aws_iam as iam,
+)
+from constructs import Construct
+
+CONNECTION_ARN = (
+    "arn:aws:codeconnections:us-east-1:579083551251"
+    ":connection/846e3503-39e0-40e6-824d-c80ca0b25cf3"
+)
+
+
+class BackendPipelineStack(Stack):
+    """CI/CD pipeline for the RunMapRepeat backend (test + cdk deploy)."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        # --- Test stage project ---
+        test_project = codebuild.PipelineProject(
+            self,
+            "BackendTest",
+            project_name="RunMapRepeat-Backend-Test",
+            build_spec=codebuild.BuildSpec.from_object(
+                {
+                    "version": 0.2,
+                    "phases": {
+                        "install": {
+                            "runtime-versions": {"python": "3.12"},
+                            "commands": [
+                                "cd $CODEBUILD_SRC_DIR/backend && pip install -r requirements.txt 2>/dev/null || true",
+                                "pip install pytest moto boto3",
+                                "cd $CODEBUILD_SRC_DIR/infra && pip install -r requirements.txt",
+                            ],
+                        },
+                        "build": {
+                            "commands": [
+                                "echo '--- Backend tests ---'",
+                                "cd $CODEBUILD_SRC_DIR/backend && python -m pytest tests/ -v",
+                                "echo '--- CDK tests ---'",
+                                "cd $CODEBUILD_SRC_DIR/infra && python -m pytest tests/ -v",
+                            ],
+                        },
+                    },
+                }
+            ),
+            environment=codebuild.BuildEnvironment(
+                build_image=codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
+                compute_type=codebuild.ComputeType.SMALL,
+            ),
+        )
+
+        # --- Deploy stage project ---
+        deploy_project = codebuild.PipelineProject(
+            self,
+            "BackendDeploy",
+            project_name="RunMapRepeat-Backend-Deploy",
+            build_spec=codebuild.BuildSpec.from_object(
+                {
+                    "version": 0.2,
+                    "phases": {
+                        "install": {
+                            "runtime-versions": {"python": "3.12", "nodejs": 22},
+                            "commands": [
+                                "npm install -g aws-cdk",
+                                "cd $CODEBUILD_SRC_DIR/infra && pip install -r requirements.txt",
+                            ],
+                        },
+                        "build": {
+                            "commands": [
+                                "cd $CODEBUILD_SRC_DIR/infra && cdk deploy RunMapRepeat-Data RunMapRepeat-Api --require-approval never",
+                            ],
+                        },
+                    },
+                }
+            ),
+            environment=codebuild.BuildEnvironment(
+                build_image=codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
+                compute_type=codebuild.ComputeType.SMALL,
+            ),
+        )
+
+        # CDK deploy needs broad permissions for CloudFormation + resources
+        deploy_project.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "cloudformation:*",
+                    "lambda:*",
+                    "apigateway:*",
+                    "dynamodb:*",
+                    "iam:*",
+                    "s3:*",
+                    "ssm:GetParameter",
+                    "ssm:GetParameters",
+                ],
+                resources=["*"],
+            )
+        )
+
+        # --- Pipeline ---
+        source_output = codepipeline.Artifact("SourceOutput")
+
+        source_action = actions.CodeStarConnectionsSourceAction(
+            action_name="GitHub_Source",
+            owner="barakcaf",
+            repo="runmaprepeat",
+            branch="main",
+            connection_arn=CONNECTION_ARN,
+            output=source_output,
+        )
+
+        test_action = actions.CodeBuildAction(
+            action_name="Test",
+            project=test_project,
+            input=source_output,
+        )
+
+        deploy_action = actions.CodeBuildAction(
+            action_name="CDK_Deploy",
+            project=deploy_project,
+            input=source_output,
+        )
+
+        codepipeline.Pipeline(
+            self,
+            "BackendPipeline",
+            pipeline_name="RunMapRepeat-Backend-Pipeline",
+            stages=[
+                codepipeline.StageProps(
+                    stage_name="Source",
+                    actions=[source_action],
+                ),
+                codepipeline.StageProps(
+                    stage_name="Test",
+                    actions=[test_action],
+                ),
+                codepipeline.StageProps(
+                    stage_name="Deploy",
+                    actions=[deploy_action],
+                ),
+            ],
+        )

--- a/infra/tests/test_backend_pipeline_stack.py
+++ b/infra/tests/test_backend_pipeline_stack.py
@@ -1,0 +1,66 @@
+"""Tests for BackendPipelineStack."""
+
+import aws_cdk as cdk
+from aws_cdk import assertions
+
+from stacks.backend_pipeline_stack import BackendPipelineStack
+
+
+def test_backend_pipeline_created() -> None:
+    app = cdk.App()
+    stack = BackendPipelineStack(
+        app,
+        "TestBackendPipeline",
+        env=cdk.Environment(account="123456789012", region="us-east-1"),
+    )
+    template = assertions.Template.from_stack(stack)
+
+    # Pipeline exists
+    template.resource_count_is("AWS::CodePipeline::Pipeline", 1)
+
+    # Three stages: Source, Test, Deploy
+    template.has_resource_properties(
+        "AWS::CodePipeline::Pipeline",
+        {
+            "Stages": assertions.Match.array_with(
+                [
+                    assertions.Match.object_like({"Name": "Source"}),
+                    assertions.Match.object_like({"Name": "Test"}),
+                    assertions.Match.object_like({"Name": "Deploy"}),
+                ]
+            ),
+        },
+    )
+
+    # Two CodeBuild projects (test + deploy)
+    template.resource_count_is("AWS::CodeBuild::Project", 2)
+
+
+def test_deploy_project_has_iam_permissions() -> None:
+    app = cdk.App()
+    stack = BackendPipelineStack(
+        app,
+        "TestBackendPipeline",
+        env=cdk.Environment(account="123456789012", region="us-east-1"),
+    )
+    template = assertions.Template.from_stack(stack)
+
+    # At least one IAM policy with cloudformation:*
+    template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": {
+                "Statement": assertions.Match.array_with(
+                    [
+                        assertions.Match.object_like(
+                            {
+                                "Action": assertions.Match.array_with(
+                                    ["cloudformation:*"]
+                                ),
+                            }
+                        ),
+                    ]
+                ),
+            },
+        },
+    )


### PR DESCRIPTION
Adds a CodePipeline for backend deployments, triggered on main push.

### Pipeline stages
1. **Source** — GitHub via CodeStar connection (same as frontend)
2. **Test** — pytest backend tests + CDK assertion tests
3. **Deploy** — `cdk deploy RunMapRepeat-Data RunMapRepeat-Api`

### New files
- `infra/stacks/backend_pipeline_stack.py` — pipeline CDK stack
- `infra/tests/test_backend_pipeline_stack.py` — CDK assertions
- Updated `infra/app.py` to include the new stack

### Tests
- 37 backend + 30 CDK = **67 total, all passing**

### Notes
- Deploy project has broad IAM perms (cloudformation, lambda, apigateway, dynamodb, iam, s3) — needed for CDK to create/update resources
- ARM64 CodeBuild (consistent with frontend pipeline)
- Uses `--require-approval never` for automated deploys