### PR TITLE
feat: run management UI — dashboard, pages, API client, navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,74 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { AuthProvider } from "./auth/AuthProvider";
 import { ProtectedRoute } from "./auth/ProtectedRoute";
 import { LoginPage } from "./auth/LoginPage";
+import { BottomNav } from "./components/NavBar/BottomNav";
 import { Dashboard } from "./pages/Dashboard";
+import { NewRunPage } from "./pages/NewRunPage";
+import { PlannedRunsPage } from "./pages/PlannedRunsPage";
+import { RunDetailPage } from "./pages/RunDetailPage";
+import { ProfilePage } from "./pages/ProfilePage";
+
+function AppRoutes() {
+  const location = useLocation();
+  const showNav = location.pathname !== "/login";
+
+  return (
+    <>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/"
+          element={
+            <ProtectedRoute>
+              <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/runs/new"
+          element={
+            <ProtectedRoute>
+              <NewRunPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/runs/:runId"
+          element={
+            <ProtectedRoute>
+              <RunDetailPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/planned"
+          element={
+            <ProtectedRoute>
+              <PlannedRunsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            <ProtectedRoute>
+              <ProfilePage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+      {showNav && <BottomNav />}
+    </>
+  );
+}
 
 function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route
-            path="/"
-            element={
-              <ProtectedRoute>
-                <Dashboard />
-              </ProtectedRoute>
-            }
-          />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
+        <AppRoutes />
       </AuthProvider>
     </BrowserRouter>
   );

--- a/frontend/src/__tests__/BottomNav.test.tsx
+++ b/frontend/src/__tests__/BottomNav.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { BottomNav } from "../components/NavBar/BottomNav";
+
+function renderWithRouter(initialPath = "/") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <BottomNav />
+    </MemoryRouter>
+  );
+}
+
+describe("BottomNav", () => {
+  it("renders all four tabs", () => {
+    renderWithRouter();
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("New Run")).toBeInTheDocument();
+    expect(screen.getByText("Planned")).toBeInTheDocument();
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+  });
+
+  it("marks Home tab as active on /", () => {
+    renderWithRouter("/");
+    const homeLink = screen.getByText("Home").closest("a");
+    expect(homeLink?.className).toContain("active");
+  });
+
+  it("marks Planned tab as active on /planned", () => {
+    renderWithRouter("/planned");
+    const plannedLink = screen.getByText("Planned").closest("a");
+    expect(plannedLink?.className).toContain("active");
+  });
+
+  it("marks Profile tab as active on /profile", () => {
+    renderWithRouter("/profile");
+    const profileLink = screen.getByText("Profile").closest("a");
+    expect(profileLink?.className).toContain("active");
+  });
+
+  it("does not mark Home as active on /planned", () => {
+    renderWithRouter("/planned");
+    const homeLink = screen.getByText("Home").closest("a");
+    expect(homeLink?.className).not.toContain("active");
+  });
+
+  it("renders the nav element with test id", () => {
+    renderWithRouter();
+    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ProfilePage } from "../pages/ProfilePage";
+
+vi.mock("../auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { email: "test@example.com", userId: "user-123" },
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock("../api/client", () => ({
+  getProfile: vi.fn().mockResolvedValue({
+    displayName: "Test User",
+    weightKg: 75,
+    heightCm: 180,
+    birthDate: "1990-01-15",
+  }),
+  updateProfile: vi.fn().mockResolvedValue({}),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ProfilePage />
+    </MemoryRouter>
+  );
+}
+
+describe("ProfilePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    renderPage();
+    expect(screen.getByText("Loading profile...")).toBeInTheDocument();
+  });
+
+  it("renders form fields after loading", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Display Name")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Weight (kg)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Height (cm)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Birth Date")).toBeInTheDocument();
+  });
+
+  it("populates form with loaded profile data", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Display Name")).toHaveValue("Test User");
+    });
+    expect(screen.getByLabelText("Weight (kg)")).toHaveValue(75);
+    expect(screen.getByLabelText("Height (cm)")).toHaveValue(180);
+    expect(screen.getByLabelText("Birth Date")).toHaveValue("1990-01-15");
+  });
+
+  it("renders save button", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Save Profile")).toBeInTheDocument();
+    });
+  });
+
+  it("renders sign out button", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatDuration,
+  formatPace,
+  formatDate,
+  formatDateTime,
+  formatCalories,
+  formatAudio,
+} from "../utils/format";
+import type { MusicAudio, PodcastAudio } from "../types/run";
+
+describe("formatDuration", () => {
+  it("formats seconds under an hour as MM:SS", () => {
+    expect(formatDuration(1935)).toBe("32:15");
+  });
+
+  it("formats seconds over an hour as H:MM:SS", () => {
+    expect(formatDuration(3735)).toBe("1:02:15");
+  });
+
+  it("pads seconds correctly", () => {
+    expect(formatDuration(61)).toBe("1:01");
+  });
+
+  it("handles zero", () => {
+    expect(formatDuration(0)).toBe("0:00");
+  });
+});
+
+describe("formatPace", () => {
+  it("formats pace as M:SS /km", () => {
+    expect(formatPace(332)).toBe("5:32 /km");
+  });
+
+  it("pads seconds", () => {
+    expect(formatPace(305)).toBe("5:05 /km");
+  });
+});
+
+describe("formatDate", () => {
+  it("formats ISO string as readable date", () => {
+    const result = formatDate("2026-03-24T07:30:00Z");
+    expect(result).toContain("Mar");
+    expect(result).toContain("24");
+    expect(result).toContain("2026");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("formats ISO string as date and time", () => {
+    const result = formatDateTime("2026-03-24T07:30:00Z");
+    expect(result).toContain("Mar");
+    expect(result).toContain("24");
+  });
+});
+
+describe("formatCalories", () => {
+  it("formats calories with comma separator and kcal", () => {
+    expect(formatCalories(1840)).toBe("1,840 kcal");
+  });
+
+  it("formats small numbers without comma", () => {
+    expect(formatCalories(500)).toBe("500 kcal");
+  });
+});
+
+describe("formatAudio", () => {
+  it("formats podcast with episode", () => {
+    const audio: PodcastAudio = {
+      type: "podcast",
+      name: "Huberman Lab",
+      detail: "Ep. 234",
+    };
+    expect(formatAudio(audio)).toBe("Huberman Lab - Ep. 234");
+  });
+
+  it("formats podcast without episode", () => {
+    const audio: PodcastAudio = { type: "podcast", name: "Huberman Lab" };
+    expect(formatAudio(audio)).toBe("Huberman Lab");
+  });
+
+  it("formats music artist with album", () => {
+    const audio: MusicAudio = {
+      type: "music",
+      subtype: "artist",
+      format: "album",
+      name: "Dua Lipa",
+      detail: "Future Nostalgia",
+    };
+    expect(formatAudio(audio)).toBe("Dua Lipa - Album: Future Nostalgia");
+  });
+
+  it("formats music artist with mix", () => {
+    const audio: MusicAudio = {
+      type: "music",
+      subtype: "artist",
+      format: "mix",
+      name: "Dua Lipa",
+      detail: "Club Mix",
+    };
+    expect(formatAudio(audio)).toBe("Dua Lipa - Mix: Club Mix");
+  });
+
+  it("formats music artist without detail", () => {
+    const audio: MusicAudio = {
+      type: "music",
+      subtype: "artist",
+      format: "album",
+      name: "Dua Lipa",
+    };
+    expect(formatAudio(audio)).toBe("Dua Lipa");
+  });
+
+  it("formats playlist", () => {
+    const audio: MusicAudio = {
+      type: "music",
+      subtype: "playlist",
+      name: "Running Hits",
+    };
+    expect(formatAudio(audio)).toBe("Running Hits");
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,90 @@
+import { fetchAuthSession } from "@aws-amplify/auth";
+import type { Run, CreateRunPayload, UpdateRunPayload, CompleteRunPayload } from "../types/run";
+import type { Profile } from "../types/profile";
+
+const BASE_URL = import.meta.env.VITE_API_URL as string;
+
+class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function getAuthToken(): Promise<string> {
+  const session = await fetchAuthSession();
+  const token = session.tokens?.idToken?.toString();
+  if (!token) {
+    throw new ApiError(401, "No valid session");
+  }
+  return token;
+}
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = await getAuthToken();
+  const response = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new ApiError(response.status, body || response.statusText);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function getProfile(): Promise<Profile> {
+  return request<Profile>("/profile");
+}
+
+export function updateProfile(data: Profile): Promise<Profile> {
+  return request<Profile>("/profile", {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export function createRun(data: CreateRunPayload): Promise<Run> {
+  return request<Run>("/runs", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function listRuns(): Promise<Run[]> {
+  return request<Run[]>("/runs");
+}
+
+export function getRun(id: string): Promise<Run> {
+  return request<Run>(`/runs/${id}`);
+}
+
+export function updateRun(id: string, data: UpdateRunPayload): Promise<Run> {
+  return request<Run>(`/runs/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteRun(id: string): Promise<void> {
+  return request<void>(`/runs/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export function completeRun(id: string, data: CompleteRunPayload): Promise<Run> {
+  return request<Run>(`/runs/${id}/complete`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}

--- a/frontend/src/components/NavBar/BottomNav.module.css
+++ b/frontend/src/components/NavBar/BottomNav.module.css
@@ -1,0 +1,45 @@
+.nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  height: 64px;
+  background-color: #1a1a1a;
+  border-top: 1px solid #333;
+  z-index: 100;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
+  min-height: 44px;
+  padding: 6px 12px;
+  text-decoration: none;
+  color: #999;
+  transition: color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.tab.active {
+  color: #ff6b35;
+}
+
+.icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.label {
+  font-size: 0.625rem;
+  margin-top: 2px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}

--- a/frontend/src/components/NavBar/BottomNav.tsx
+++ b/frontend/src/components/NavBar/BottomNav.tsx
@@ -1,0 +1,29 @@
+import { NavLink } from "react-router-dom";
+import styles from "./BottomNav.module.css";
+
+const tabs = [
+  { to: "/", label: "Home", icon: "\u{1F3E0}" },
+  { to: "/runs/new", label: "New Run", icon: "\u{2795}" },
+  { to: "/planned", label: "Planned", icon: "\u{1F4CB}" },
+  { to: "/profile", label: "Profile", icon: "\u{1F464}" },
+] as const;
+
+export function BottomNav() {
+  return (
+    <nav className={styles.nav} data-testid="bottom-nav">
+      {tabs.map((tab) => (
+        <NavLink
+          key={tab.to}
+          to={tab.to}
+          end={tab.to === "/"}
+          className={({ isActive }) =>
+            `${styles.tab} ${isActive ? styles.active : ""}`
+          }
+        >
+          <span className={styles.icon}>{tab.icon}</span>
+          <span className={styles.label}>{tab.label}</span>
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,23 +1,189 @@
+import { useEffect, useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthProvider";
+import { listRuns } from "../api/client";
+import { formatDuration, formatPace, formatDate, formatDateTime, formatCalories, formatAudio } from "../utils/format";
+import type { Run } from "../types/run";
+import shared from "../styles/shared.module.css";
 import styles from "../styles/Dashboard.module.css";
 
+function getWeekStart(): Date {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  const monday = new Date(now);
+  monday.setHours(0, 0, 0, 0);
+  monday.setDate(monday.getDate() - diff);
+  return monday;
+}
+
+interface WeeklyStats {
+  runCount: number;
+  totalDistanceKm: number;
+  totalCalories: number;
+  avgPaceSecondsPerKm: number | null;
+}
+
+function computeWeeklyStats(runs: Run[]): WeeklyStats {
+  const weekStart = getWeekStart();
+  const weekRuns = runs.filter(
+    (r) => r.status === "completed" && new Date(r.runDate) >= weekStart
+  );
+  const totalDistanceKm = weekRuns.reduce(
+    (sum, r) => sum + (r.distanceMeters ?? 0) / 1000,
+    0
+  );
+  const totalCalories = weekRuns.reduce(
+    (sum, r) => sum + (r.caloriesBurned ?? 0),
+    0
+  );
+  const paces = weekRuns
+    .map((r) => r.paceSecondsPerKm)
+    .filter((p): p is number => p !== undefined && p > 0);
+  const avgPace = paces.length > 0
+    ? paces.reduce((a, b) => a + b, 0) / paces.length
+    : null;
+
+  return {
+    runCount: weekRuns.length,
+    totalDistanceKm,
+    totalCalories,
+    avgPaceSecondsPerKm: avgPace,
+  };
+}
+
 export function Dashboard() {
-  const { user, signOut } = useAuth();
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    listRuns()
+      .then((data) => {
+        if (!cancelled) setRuns(data);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const completedRuns = useMemo(
+    () =>
+      runs
+        .filter((r) => r.status === "completed")
+        .sort((a, b) => new Date(b.runDate).getTime() - new Date(a.runDate).getTime()),
+    [runs]
+  );
+
+  const weekly = useMemo(() => computeWeeklyStats(runs), [runs]);
+
+  if (loading) {
+    return (
+      <div className={shared.page}>
+        <div className={shared.loadingState}>Loading runs...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={shared.page}>
+        <div className={shared.errorState}>Failed to load runs: {error}</div>
+      </div>
+    );
+  }
 
   return (
-    <div className={styles.container}>
-      <header className={styles.header}>
-        <h1 className={styles.title}>Welcome to RunMapRepeat</h1>
-        <div className={styles.userInfo}>
-          <span className={styles.email}>{user?.email}</span>
-          <button onClick={signOut} className={styles.signOutButton}>
-            Sign out
-          </button>
+    <div className={shared.page}>
+      <div className={shared.pageHeader}>
+        <h1 className={shared.pageTitle}>
+          Hi, {user?.email?.split("@")[0] ?? "Runner"}
+        </h1>
+      </div>
+
+      <div className={styles.weeklyStats}>
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>🏃</div>
+          <div className={styles.statValue}>{weekly.runCount}</div>
+          <div className={styles.statLabel}>Runs this week</div>
         </div>
-      </header>
-      <main className={styles.main}>
-        <p className={styles.placeholder}>Your runs will appear here</p>
-      </main>
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>📏</div>
+          <div className={styles.statValue}>{weekly.totalDistanceKm.toFixed(1)}</div>
+          <div className={styles.statLabel}>km this week</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>🔥</div>
+          <div className={styles.statValue}>{Math.round(weekly.totalCalories)}</div>
+          <div className={styles.statLabel}>kcal burned</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>⚡</div>
+          <div className={styles.statValue}>
+            {weekly.avgPaceSecondsPerKm
+              ? formatPace(weekly.avgPaceSecondsPerKm).replace(" /km", "")
+              : "--"}
+          </div>
+          <div className={styles.statLabel}>avg pace /km</div>
+        </div>
+      </div>
+
+      <h2 className={styles.sectionTitle}>Recent Runs</h2>
+
+      {completedRuns.length === 0 ? (
+        <div className={shared.emptyState}>
+          No completed runs yet. Lace up and go!
+        </div>
+      ) : (
+        completedRuns.map((run) => (
+          <div
+            key={run.runId}
+            className={`${shared.card} ${styles.runCard}`}
+            onClick={() => navigate(`/runs/${run.runId}`)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") navigate(`/runs/${run.runId}`);
+            }}
+          >
+            <div className={shared.mapPlaceholder}>Route map</div>
+            <div className={shared.cardTitle}>
+              {run.title || "Untitled Run"}
+            </div>
+            <div className={shared.cardMeta}>
+              {formatDateTime(run.runDate)}
+            </div>
+            <div className={shared.statsRow}>
+              {run.distanceMeters !== undefined && (
+                <span>{(run.distanceMeters / 1000).toFixed(2)} km</span>
+              )}
+              {run.durationSeconds !== undefined && (
+                <span>{formatDuration(run.durationSeconds)}</span>
+              )}
+              {run.paceSecondsPerKm !== undefined && (
+                <span>{formatPace(run.paceSecondsPerKm)}</span>
+              )}
+              {run.caloriesBurned !== undefined && (
+                <span>{formatCalories(run.caloriesBurned)}</span>
+              )}
+            </div>
+            {run.audio && (
+              <div className={shared.audioLine}>
+                {run.audio.type === "music" ? "🎵" : "🎙️"}{" "}
+                {formatAudio(run.audio)}
+              </div>
+            )}
+          </div>
+        ))
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/NewRunPage.tsx
+++ b/frontend/src/pages/NewRunPage.tsx
@@ -1,0 +1,336 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createRun } from "../api/client";
+import type { Audio, CreateRunPayload } from "../types/run";
+import shared from "../styles/shared.module.css";
+import styles from "../styles/NewRunPage.module.css";
+
+function toISOLocal(date: string, time: string): string {
+  return new Date(`${date}T${time}`).toISOString();
+}
+
+function nowDate(): string {
+  const d = new Date();
+  return d.toISOString().slice(0, 10);
+}
+
+function nowTime(): string {
+  const d = new Date();
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+export function NewRunPage() {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState("");
+  const [date, setDate] = useState(nowDate);
+  const [time, setTime] = useState(nowTime);
+  const [status, setStatus] = useState<"completed" | "planned">("completed");
+  const [durationInput, setDurationInput] = useState("");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [audioType, setAudioType] = useState<"music" | "podcast">("music");
+  const [musicSubtype, setMusicSubtype] = useState<"artist" | "playlist">("artist");
+  const [audioName, setAudioName] = useState("");
+  const [audioDetail, setAudioDetail] = useState("");
+  const [artistFormat, setArtistFormat] = useState<"album" | "mix">("album");
+
+  function parseDuration(input: string): number | null {
+    if (!input.trim()) return null;
+    const parts = input.split(":").map(Number);
+    if (parts.some(isNaN)) return null;
+    if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    if (parts.length === 2) return parts[0] * 60 + parts[1];
+    return null;
+  }
+
+  function buildAudio(): Audio | undefined {
+    if (!audioName.trim()) return undefined;
+    if (audioType === "podcast") {
+      return {
+        type: "podcast",
+        name: audioName.trim(),
+        ...(audioDetail.trim() ? { detail: audioDetail.trim() } : {}),
+      };
+    }
+    if (musicSubtype === "playlist") {
+      return {
+        type: "music",
+        subtype: "playlist",
+        name: audioName.trim(),
+      };
+    }
+    return {
+      type: "music",
+      subtype: "artist",
+      format: artistFormat,
+      name: audioName.trim(),
+      ...(audioDetail.trim() ? { detail: audioDetail.trim() } : {}),
+    };
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    const durationSeconds = parseDuration(durationInput);
+    if (status === "completed" && (durationSeconds === null || durationSeconds <= 0)) {
+      setError("Please enter a valid duration");
+      setSaving(false);
+      return;
+    }
+
+    const payload: CreateRunPayload = {
+      status,
+      runDate: toISOLocal(date, time),
+      ...(title.trim() ? { title: title.trim() } : {}),
+      ...(status === "completed" && durationSeconds ? { durationSeconds } : {}),
+      ...(notes.trim() ? { notes: notes.trim() } : {}),
+      audio: buildAudio(),
+    };
+
+    try {
+      const run = await createRun(payload);
+      navigate(`/runs/${run.runId}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to create run";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className={shared.page}>
+      <div className={styles.mapArea}>Map component loading...</div>
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <h2 className={styles.formTitle}>New Run</h2>
+
+        {error && <div className={shared.errorState}>{error}</div>}
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="title">Title</label>
+          <input
+            id="title"
+            className={shared.formInput}
+            type="text"
+            placeholder="Morning run"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="date">Date</label>
+          <input
+            id="date"
+            className={shared.formInput}
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="time">Time</label>
+          <input
+            id="time"
+            className={shared.formInput}
+            type="time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel}>Status</label>
+          <div className={shared.toggleGroup}>
+            <button
+              type="button"
+              className={status === "completed" ? shared.toggleOptionActive : shared.toggleOption}
+              onClick={() => setStatus("completed")}
+            >
+              Completed
+            </button>
+            <button
+              type="button"
+              className={status === "planned" ? shared.toggleOptionActive : shared.toggleOption}
+              onClick={() => setStatus("planned")}
+            >
+              Planned
+            </button>
+          </div>
+        </div>
+
+        {status === "completed" && (
+          <div className={shared.formGroup}>
+            <label className={shared.formLabel} htmlFor="duration">
+              Duration (HH:MM:SS)
+            </label>
+            <input
+              id="duration"
+              className={shared.formInput}
+              type="text"
+              placeholder="0:32:15"
+              value={durationInput}
+              onChange={(e) => setDurationInput(e.target.value)}
+            />
+          </div>
+        )}
+
+        <div className={styles.audioSection}>
+          <div className={styles.audioSectionTitle}>Audio</div>
+          <div className={shared.formGroup}>
+            <div className={shared.toggleGroup}>
+              <button
+                type="button"
+                className={audioType === "music" ? shared.toggleOptionActive : shared.toggleOption}
+                onClick={() => setAudioType("music")}
+              >
+                🎵 Music
+              </button>
+              <button
+                type="button"
+                className={audioType === "podcast" ? shared.toggleOptionActive : shared.toggleOption}
+                onClick={() => setAudioType("podcast")}
+              >
+                🎙️ Podcast
+              </button>
+            </div>
+          </div>
+
+          {audioType === "music" && (
+            <div className={shared.formGroup}>
+              <div className={shared.toggleGroup}>
+                <button
+                  type="button"
+                  className={musicSubtype === "artist" ? shared.toggleOptionActive : shared.toggleOption}
+                  onClick={() => setMusicSubtype("artist")}
+                >
+                  Artist
+                </button>
+                <button
+                  type="button"
+                  className={musicSubtype === "playlist" ? shared.toggleOptionActive : shared.toggleOption}
+                  onClick={() => setMusicSubtype("playlist")}
+                >
+                  Playlist
+                </button>
+              </div>
+            </div>
+          )}
+
+          {audioType === "music" && musicSubtype === "artist" && (
+            <>
+              <div className={shared.formGroup}>
+                <label className={shared.formLabel} htmlFor="artistName">Artist</label>
+                <input
+                  id="artistName"
+                  className={shared.formInput}
+                  type="text"
+                  placeholder="Artist name"
+                  value={audioName}
+                  onChange={(e) => setAudioName(e.target.value)}
+                />
+              </div>
+              <div className={shared.formGroup}>
+                <div className={shared.toggleGroup}>
+                  <button
+                    type="button"
+                    className={artistFormat === "album" ? shared.toggleOptionActive : shared.toggleOption}
+                    onClick={() => setArtistFormat("album")}
+                  >
+                    Album
+                  </button>
+                  <button
+                    type="button"
+                    className={artistFormat === "mix" ? shared.toggleOptionActive : shared.toggleOption}
+                    onClick={() => setArtistFormat("mix")}
+                  >
+                    Mix
+                  </button>
+                </div>
+              </div>
+              {artistFormat === "album" && (
+                <div className={shared.formGroup}>
+                  <label className={shared.formLabel} htmlFor="albumName">Album</label>
+                  <input
+                    id="albumName"
+                    className={shared.formInput}
+                    type="text"
+                    placeholder="Album name"
+                    value={audioDetail}
+                    onChange={(e) => setAudioDetail(e.target.value)}
+                  />
+                </div>
+              )}
+            </>
+          )}
+
+          {audioType === "music" && musicSubtype === "playlist" && (
+            <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="playlistName">Playlist</label>
+              <input
+                id="playlistName"
+                className={shared.formInput}
+                type="text"
+                placeholder="Playlist name"
+                value={audioName}
+                onChange={(e) => setAudioName(e.target.value)}
+              />
+            </div>
+          )}
+
+          {audioType === "podcast" && (
+            <>
+              <div className={shared.formGroup}>
+                <label className={shared.formLabel} htmlFor="podcastName">Podcast</label>
+                <input
+                  id="podcastName"
+                  className={shared.formInput}
+                  type="text"
+                  placeholder="Podcast name"
+                  value={audioName}
+                  onChange={(e) => setAudioName(e.target.value)}
+                />
+              </div>
+              <div className={shared.formGroup}>
+                <label className={shared.formLabel} htmlFor="episode">Episode</label>
+                <input
+                  id="episode"
+                  className={shared.formInput}
+                  type="text"
+                  placeholder="Episode (optional)"
+                  value={audioDetail}
+                  onChange={(e) => setAudioDetail(e.target.value)}
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="notes">Notes</label>
+          <textarea
+            id="notes"
+            className={shared.formTextarea}
+            placeholder="How did it go?"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+        </div>
+
+        <button
+          type="submit"
+          className={shared.buttonPrimary}
+          disabled={saving}
+          style={{ width: "100%" }}
+        >
+          {saving ? "Saving..." : "Save Run"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/PlannedRunsPage.tsx
+++ b/frontend/src/pages/PlannedRunsPage.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState, useCallback } from "react";
+import { listRuns, completeRun, deleteRun } from "../api/client";
+import { formatDate } from "../utils/format";
+import type { Run } from "../types/run";
+import shared from "../styles/shared.module.css";
+import styles from "../styles/PlannedRunsPage.module.css";
+
+export function PlannedRunsPage() {
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [completing, setCompleting] = useState<string | null>(null);
+  const [durationInput, setDurationInput] = useState("");
+
+  const loadRuns = useCallback(() => {
+    setLoading(true);
+    listRuns()
+      .then((data) => {
+        setRuns(
+          data
+            .filter((r) => r.status === "planned")
+            .sort((a, b) => new Date(a.runDate).getTime() - new Date(b.runDate).getTime())
+        );
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  function parseDuration(input: string): number | null {
+    const parts = input.split(":").map(Number);
+    if (parts.some(isNaN)) return null;
+    if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    if (parts.length === 2) return parts[0] * 60 + parts[1];
+    return null;
+  }
+
+  async function handleComplete() {
+    if (!completing) return;
+    const seconds = parseDuration(durationInput);
+    if (!seconds || seconds <= 0) return;
+
+    try {
+      await completeRun(completing, { durationSeconds: seconds });
+      setCompleting(null);
+      setDurationInput("");
+      loadRuns();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to complete run";
+      setError(message);
+    }
+  }
+
+  async function handleDelete(runId: string) {
+    if (!window.confirm("Delete this planned run?")) return;
+    try {
+      await deleteRun(runId);
+      loadRuns();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to delete run";
+      setError(message);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className={shared.page}>
+        <div className={shared.loadingState}>Loading planned runs...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={shared.page}>
+        <div className={shared.errorState}>{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={shared.page}>
+      <div className={shared.pageHeader}>
+        <h1 className={shared.pageTitle}>Planned Runs</h1>
+      </div>
+
+      {runs.length === 0 ? (
+        <div className={shared.emptyState}>
+          No planned runs. Create one from the New Run page!
+        </div>
+      ) : (
+        runs.map((run) => (
+          <div key={run.runId} className={shared.card}>
+            <div className={shared.mapPlaceholder}>Route map</div>
+            <div className={shared.cardTitle}>
+              {run.title || "Untitled Run"}
+            </div>
+            <div className={shared.cardMeta}>{formatDate(run.runDate)}</div>
+            {run.distanceMeters !== undefined && (
+              <div className={shared.statsRow}>
+                <span>{(run.distanceMeters / 1000).toFixed(2)} km</span>
+              </div>
+            )}
+            <div className={styles.actions}>
+              <button
+                className={shared.buttonPrimary}
+                onClick={() => {
+                  setCompleting(run.runId);
+                  setDurationInput("");
+                }}
+              >
+                Run it!
+              </button>
+              <button
+                className={shared.buttonDanger}
+                onClick={() => handleDelete(run.runId)}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        ))
+      )}
+
+      {completing && (
+        <div className={styles.modal} onClick={() => setCompleting(null)}>
+          <div
+            className={styles.modalContent}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className={styles.modalTitle}>Complete Run</h3>
+            <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="duration">
+                Duration (HH:MM:SS or MM:SS)
+              </label>
+              <input
+                id="duration"
+                className={shared.formInput}
+                type="text"
+                placeholder="32:15"
+                value={durationInput}
+                onChange={(e) => setDurationInput(e.target.value)}
+              />
+            </div>
+            <div className={styles.modalActions}>
+              <button className={shared.buttonPrimary} onClick={handleComplete}>
+                Complete
+              </button>
+              <button
+                className={shared.buttonSecondary}
+                onClick={() => setCompleting(null)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import { getProfile, updateProfile } from "../api/client";
+import type { Profile } from "../types/profile";
+import shared from "../styles/shared.module.css";
+import styles from "../styles/ProfilePage.module.css";
+
+export function ProfilePage() {
+  const { signOut } = useAuth();
+  const [displayName, setDisplayName] = useState("");
+  const [weightKg, setWeightKg] = useState("");
+  const [heightCm, setHeightCm] = useState("");
+  const [birthDate, setBirthDate] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    getProfile()
+      .then((profile) => {
+        setDisplayName(profile.displayName ?? "");
+        setWeightKg(profile.weightKg?.toString() ?? "");
+        setHeightCm(profile.heightCm?.toString() ?? "");
+        setBirthDate(profile.birthDate ?? "");
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    const data: Profile = {};
+    if (displayName.trim()) data.displayName = displayName.trim();
+    if (weightKg) data.weightKg = Number(weightKg);
+    if (heightCm) data.heightCm = Number(heightCm);
+    if (birthDate) data.birthDate = birthDate;
+
+    try {
+      await updateProfile(data);
+      setSuccess(true);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to save profile";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className={shared.page}>
+        <div className={shared.loadingState}>Loading profile...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={shared.page}>
+      <div className={shared.pageHeader}>
+        <h1 className={shared.pageTitle}>Profile</h1>
+      </div>
+
+      <form className={shared.card} onSubmit={handleSave}>
+        {error && <div className={shared.errorState}>{error}</div>}
+        {success && <div className={styles.success}>Profile saved!</div>}
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="displayName">Display Name</label>
+          <input
+            id="displayName"
+            className={shared.formInput}
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="weightKg">Weight (kg)</label>
+          <input
+            id="weightKg"
+            className={shared.formInput}
+            type="number"
+            step="0.1"
+            value={weightKg}
+            onChange={(e) => setWeightKg(e.target.value)}
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="heightCm">Height (cm)</label>
+          <input
+            id="heightCm"
+            className={shared.formInput}
+            type="number"
+            value={heightCm}
+            onChange={(e) => setHeightCm(e.target.value)}
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="birthDate">Birth Date</label>
+          <input
+            id="birthDate"
+            className={shared.formInput}
+            type="date"
+            value={birthDate}
+            onChange={(e) => setBirthDate(e.target.value)}
+          />
+        </div>
+
+        <button
+          type="submit"
+          className={shared.buttonPrimary}
+          disabled={saving}
+          style={{ width: "100%" }}
+        >
+          {saving ? "Saving..." : "Save Profile"}
+        </button>
+
+        <div className={styles.signOutSection}>
+          <button
+            type="button"
+            className={shared.buttonSecondary}
+            onClick={signOut}
+            style={{ width: "100%" }}
+          >
+            Sign Out
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getRun, updateRun, deleteRun, completeRun } from "../api/client";
+import { formatDuration, formatPace, formatDate, formatCalories, formatAudio } from "../utils/format";
+import type { Run } from "../types/run";
+import shared from "../styles/shared.module.css";
+import styles from "../styles/RunDetailPage.module.css";
+
+export function RunDetailPage() {
+  const { runId } = useParams<{ runId: string }>();
+  const navigate = useNavigate();
+  const [run, setRun] = useState<Run | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editNotes, setEditNotes] = useState("");
+  const [editDate, setEditDate] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const [completing, setCompleting] = useState(false);
+  const [durationInput, setDurationInput] = useState("");
+
+  useEffect(() => {
+    if (!runId) return;
+    setLoading(true);
+    getRun(runId)
+      .then((data) => {
+        setRun(data);
+        setEditTitle(data.title ?? "");
+        setEditNotes(data.notes ?? "");
+        setEditDate(data.runDate.slice(0, 10));
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [runId]);
+
+  async function handleSaveEdit() {
+    if (!runId) return;
+    setSaving(true);
+    try {
+      const updated = await updateRun(runId, {
+        title: editTitle.trim() || undefined,
+        notes: editNotes.trim() || undefined,
+        runDate: editDate ? new Date(editDate).toISOString() : undefined,
+      });
+      setRun(updated);
+      setEditing(false);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to save";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!runId || !window.confirm("Delete this run? This cannot be undone.")) return;
+    try {
+      await deleteRun(runId);
+      navigate("/");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to delete";
+      setError(message);
+    }
+  }
+
+  function parseDuration(input: string): number | null {
+    const parts = input.split(":").map(Number);
+    if (parts.some(isNaN)) return null;
+    if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    if (parts.length === 2) return parts[0] * 60 + parts[1];
+    return null;
+  }
+
+  async function handleComplete() {
+    if (!runId) return;
+    const seconds = parseDuration(durationInput);
+    if (!seconds || seconds <= 0) return;
+    setSaving(true);
+    try {
+      const updated = await completeRun(runId, { durationSeconds: seconds });
+      setRun(updated);
+      setCompleting(false);
+      setDurationInput("");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to complete run";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className={shared.page}>
+        <div className={shared.loadingState}>Loading run...</div>
+      </div>
+    );
+  }
+
+  if (error && !run) {
+    return (
+      <div className={shared.page}>
+        <div className={shared.errorState}>{error}</div>
+      </div>
+    );
+  }
+
+  if (!run) return null;
+
+  return (
+    <div className={shared.page}>
+      <div className={styles.mapArea}>Route map</div>
+      <div className={styles.detailCard}>
+        {error && <div className={shared.errorState}>{error}</div>}
+
+        {editing ? (
+          <div className={styles.editForm}>
+            <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="editTitle">Title</label>
+              <input
+                id="editTitle"
+                className={shared.formInput}
+                value={editTitle}
+                onChange={(e) => setEditTitle(e.target.value)}
+              />
+            </div>
+            <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="editDate">Date</label>
+              <input
+                id="editDate"
+                className={shared.formInput}
+                type="date"
+                value={editDate}
+                onChange={(e) => setEditDate(e.target.value)}
+              />
+            </div>
+            <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="editNotes">Notes</label>
+              <textarea
+                id="editNotes"
+                className={shared.formTextarea}
+                value={editNotes}
+                onChange={(e) => setEditNotes(e.target.value)}
+              />
+            </div>
+            <div className={styles.actions}>
+              <button className={shared.buttonPrimary} onClick={handleSaveEdit} disabled={saving}>
+                {saving ? "Saving..." : "Save"}
+              </button>
+              <button className={shared.buttonSecondary} onClick={() => setEditing(false)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <h1 className={styles.runTitle}>{run.title || "Untitled Run"}</h1>
+            <div className={styles.runDate}>{formatDate(run.runDate)}</div>
+
+            <div className={styles.statsGrid}>
+              {run.distanceMeters !== undefined && (
+                <div className={styles.statItem}>
+                  <div className={styles.statItemLabel}>Distance</div>
+                  <div className={styles.statItemValue}>
+                    {(run.distanceMeters / 1000).toFixed(2)} km
+                  </div>
+                </div>
+              )}
+              {run.durationSeconds !== undefined && (
+                <div className={styles.statItem}>
+                  <div className={styles.statItemLabel}>Duration</div>
+                  <div className={styles.statItemValue}>
+                    {formatDuration(run.durationSeconds)}
+                  </div>
+                </div>
+              )}
+              {run.paceSecondsPerKm !== undefined && (
+                <div className={styles.statItem}>
+                  <div className={styles.statItemLabel}>Pace</div>
+                  <div className={styles.statItemValue}>
+                    {formatPace(run.paceSecondsPerKm)}
+                  </div>
+                </div>
+              )}
+              {run.caloriesBurned !== undefined && (
+                <div className={styles.statItem}>
+                  <div className={styles.statItemLabel}>Calories</div>
+                  <div className={styles.statItemValue}>
+                    {formatCalories(run.caloriesBurned)}
+                  </div>
+                </div>
+              )}
+              {run.elevationGainMeters !== undefined && (
+                <div className={styles.statItem}>
+                  <div className={styles.statItemLabel}>Elevation</div>
+                  <div className={styles.statItemValue}>
+                    {run.elevationGainMeters} m
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {run.audio && (
+              <div className={styles.section}>
+                <div className={styles.sectionLabel}>Audio</div>
+                <div className={styles.sectionValue}>
+                  {run.audio.type === "music" ? "🎵" : "🎙️"}{" "}
+                  {formatAudio(run.audio)}
+                </div>
+              </div>
+            )}
+
+            {run.notes && (
+              <div className={styles.section}>
+                <div className={styles.sectionLabel}>Notes</div>
+                <div className={styles.sectionValue}>{run.notes}</div>
+              </div>
+            )}
+
+            <div className={styles.actions}>
+              <button className={shared.buttonSecondary} onClick={() => setEditing(true)}>
+                Edit
+              </button>
+              {run.status === "planned" && !completing && (
+                <button className={shared.buttonPrimary} onClick={() => setCompleting(true)}>
+                  Complete Run
+                </button>
+              )}
+              <button className={shared.buttonDanger} onClick={handleDelete}>
+                Delete
+              </button>
+            </div>
+
+            {completing && (
+              <div className={styles.editForm}>
+                <div className={shared.formGroup}>
+                  <label className={shared.formLabel} htmlFor="completeDuration">
+                    Duration (HH:MM:SS or MM:SS)
+                  </label>
+                  <input
+                    id="completeDuration"
+                    className={shared.formInput}
+                    type="text"
+                    placeholder="32:15"
+                    value={durationInput}
+                    onChange={(e) => setDurationInput(e.target.value)}
+                  />
+                </div>
+                <div className={styles.actions}>
+                  <button className={shared.buttonPrimary} onClick={handleComplete} disabled={saving}>
+                    {saving ? "Completing..." : "Submit"}
+                  </button>
+                  <button className={shared.buttonSecondary} onClick={() => setCompleting(false)}>
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/Dashboard.module.css
+++ b/frontend/src/styles/Dashboard.module.css
@@ -1,56 +1,69 @@
-.container {
-  min-height: 100vh;
-  background-color: #f5f5f5;
-}
-
-.header {
+.weeklyStats {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  background-color: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding: 0.5rem 1rem;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
 }
 
-.title {
-  margin: 0;
+.weeklyStats::-webkit-scrollbar {
+  display: none;
+}
+
+.statCard {
+  flex: 0 0 auto;
+  min-width: 130px;
+  background: #ff6b35;
+  border-radius: 12px;
+  padding: 0.875rem 1rem;
+  color: #fff;
+  scroll-snap-align: start;
+}
+
+.statCard:nth-child(2) {
+  background: #e85d2c;
+}
+
+.statCard:nth-child(3) {
+  background: #d14e1f;
+}
+
+.statCard:nth-child(4) {
+  background: #c04418;
+}
+
+.statIcon {
   font-size: 1.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.statValue {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.statLabel {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.85;
+}
+
+.sectionTitle {
+  margin: 1rem 1rem 0.25rem;
+  font-size: 1rem;
+  font-weight: 700;
   color: #1a1a1a;
 }
 
-.userInfo {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.email {
-  font-size: 0.875rem;
-  color: #666;
-}
-
-.signOutButton {
-  padding: 0.5rem 1rem;
-  background: none;
-  border: 1px solid #ddd;
-  border-radius: 6px;
-  font-size: 0.875rem;
-  color: #333;
+.runCard {
   cursor: pointer;
-  transition: background-color 0.15s;
+  transition: transform 0.1s;
 }
 
-.signOutButton:hover {
-  background-color: #f5f5f5;
-}
-
-.main {
-  padding: 2rem;
-}
-
-.placeholder {
-  text-align: center;
-  color: #999;
-  font-size: 1.125rem;
-  margin-top: 4rem;
+.runCard:active {
+  transform: scale(0.98);
 }

--- a/frontend/src/styles/NewRunPage.module.css
+++ b/frontend/src/styles/NewRunPage.module.css
@@ -1,0 +1,40 @@
+.mapArea {
+  background: #e0e0e0;
+  height: 250px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 1rem;
+}
+
+.form {
+  background: #fff;
+  border-radius: 16px 16px 0 0;
+  margin-top: -16px;
+  position: relative;
+  padding: 1.25rem 1rem 2rem;
+}
+
+.formTitle {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.audioSection {
+  background: #f9f9f9;
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.audioSectionTitle {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/styles/PlannedRunsPage.module.css
+++ b/frontend/src/styles/PlannedRunsPage.module.css
@@ -1,0 +1,37 @@
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  padding: 1rem;
+}
+
+.modalContent {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 360px;
+}
+
+.modalTitle {
+  margin: 0 0 1rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.modalActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/frontend/src/styles/ProfilePage.module.css
+++ b/frontend/src/styles/ProfilePage.module.css
@@ -1,0 +1,19 @@
+.feedback {
+  padding: 0.75rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.success {
+  composes: feedback;
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.signOutSection {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #eee;
+}

--- a/frontend/src/styles/RunDetailPage.module.css
+++ b/frontend/src/styles/RunDetailPage.module.css
@@ -1,0 +1,85 @@
+.mapArea {
+  background: #e0e0e0;
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 1rem;
+}
+
+.detailCard {
+  background: #fff;
+  border-radius: 16px 16px 0 0;
+  margin-top: -16px;
+  position: relative;
+  padding: 1.25rem 1rem 2rem;
+}
+
+.runTitle {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.runDate {
+  font-size: 0.875rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.statItem {
+  background: #f9f9f9;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
+.statItemLabel {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #666;
+}
+
+.statItemValue {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin-top: 0.125rem;
+}
+
+.section {
+  margin-top: 1rem;
+}
+
+.sectionLabel {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.sectionValue {
+  font-size: 1rem;
+  color: #1a1a1a;
+  margin-top: 0.25rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.editForm {
+  margin-top: 1rem;
+}

--- a/frontend/src/styles/shared.module.css
+++ b/frontend/src/styles/shared.module.css
@@ -1,0 +1,199 @@
+.page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+  padding-bottom: 80px;
+}
+
+.pageHeader {
+  padding: 1rem 1rem 0.5rem;
+}
+
+.pageTitle {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  padding: 1rem;
+  margin: 0.5rem 1rem;
+}
+
+.cardTitle {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.cardMeta {
+  font-size: 0.8125rem;
+  color: #666;
+}
+
+.statsRow {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: #666;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mapPlaceholder {
+  background: #e8e8e8;
+  border-radius: 8px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+
+.emptyState {
+  text-align: center;
+  color: #999;
+  padding: 3rem 1rem;
+  font-size: 1rem;
+}
+
+.loadingState {
+  text-align: center;
+  color: #999;
+  padding: 3rem 1rem;
+}
+
+.errorState {
+  text-align: center;
+  color: #d32f2f;
+  padding: 2rem 1rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.625rem 1.25rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.buttonPrimary {
+  composes: button;
+  background-color: #ff6b35;
+  color: #fff;
+}
+
+.buttonPrimary:hover {
+  background-color: #e55a2b;
+}
+
+.buttonPrimary:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.buttonSecondary {
+  composes: button;
+  background-color: #e8e8e8;
+  color: #1a1a1a;
+}
+
+.buttonSecondary:hover {
+  background-color: #ddd;
+}
+
+.buttonDanger {
+  composes: button;
+  background-color: #d32f2f;
+  color: #fff;
+}
+
+.buttonDanger:hover {
+  background-color: #b71c1c;
+}
+
+.formGroup {
+  margin-bottom: 1rem;
+}
+
+.formLabel {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #666;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.formInput {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  color: #1a1a1a;
+  background: #fff;
+  min-height: 44px;
+}
+
+.formInput:focus {
+  outline: none;
+  border-color: #ff6b35;
+  box-shadow: 0 0 0 2px rgba(255, 107, 53, 0.2);
+}
+
+.formTextarea {
+  composes: formInput;
+  min-height: 80px;
+  resize: vertical;
+}
+
+.toggleGroup {
+  display: flex;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #ddd;
+}
+
+.toggleOption {
+  flex: 1;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: #fff;
+  color: #666;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.toggleOptionActive {
+  composes: toggleOption;
+  background-color: #ff6b35;
+  color: #fff;
+}
+
+.audioLine {
+  font-size: 0.8125rem;
+  color: #666;
+  margin-top: 0.25rem;
+}

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -1,0 +1,7 @@
+export interface Profile {
+  weightKg?: number;
+  heightCm?: number;
+  birthDate?: string;
+  displayName?: string;
+  updatedAt?: string;
+}

--- a/frontend/src/types/run.ts
+++ b/frontend/src/types/run.ts
@@ -1,12 +1,20 @@
 export type Coordinate = [number, number]; // [lng, lat] — MapLibre convention
 
-export interface Audio {
-  type: "music" | "podcast";
-  subtype?: string;
-  format?: string;
+export interface MusicAudio {
+  type: "music";
+  subtype: "artist" | "playlist";
+  name: string;
+  detail?: string;
+  format?: "album" | "mix";
+}
+
+export interface PodcastAudio {
+  type: "podcast";
   name: string;
   detail?: string;
 }
+
+export type Audio = MusicAudio | PodcastAudio;
 
 export interface Run {
   runId: string;
@@ -18,17 +26,36 @@ export interface Run {
   route?: Coordinate[];
   distanceMeters?: number;
   durationSeconds?: number;
+  elevationGainMeters?: number;
+  notes?: string;
+  audio?: Audio;
   paceSecondsPerKm?: number;
   caloriesBurned?: number;
+}
+
+export interface CreateRunPayload {
+  status: "planned" | "completed";
+  runDate: string;
+  title?: string;
+  route?: Coordinate[];
+  distanceMeters?: number;
+  durationSeconds?: number;
   elevationGainMeters?: number;
   notes?: string;
   audio?: Audio;
 }
 
-export interface UserProfile {
-  weightKg: number;
-  heightCm: number;
-  birthDate: string;
-  displayName?: string;
-  updatedAt: string;
+export interface UpdateRunPayload {
+  title?: string;
+  runDate?: string;
+  notes?: string;
+  route?: Coordinate[];
+  distanceMeters?: number;
+  durationSeconds?: number;
+  elevationGainMeters?: number;
+  audio?: Audio;
+}
+
+export interface CompleteRunPayload {
+  durationSeconds: number;
 }

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,60 @@
+import type { Audio } from "../types/run";
+
+export function formatDuration(seconds: number): string {
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+  const pad = (n: number) => String(n).padStart(2, "0");
+
+  if (hrs > 0) {
+    return `${hrs}:${pad(mins)}:${pad(secs)}`;
+  }
+  return `${mins}:${pad(secs)}`;
+}
+
+export function formatPace(secondsPerKm: number): string {
+  const mins = Math.floor(secondsPerKm / 60);
+  const secs = Math.floor(secondsPerKm % 60);
+  return `${mins}:${String(secs).padStart(2, "0")} /km`;
+}
+
+export function formatDate(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export function formatCalories(cal: number): string {
+  return `${cal.toLocaleString("en-US")} kcal`;
+}
+
+export function formatAudio(audio: Audio): string {
+  if (audio.type === "podcast") {
+    return audio.detail
+      ? `${audio.name} - ${audio.detail}`
+      : audio.name;
+  }
+  if (audio.subtype === "playlist") {
+    return audio.name;
+  }
+  // artist
+  const label = audio.format === "album" ? "Album" : "Mix";
+  if (audio.detail) {
+    return `${audio.name} - ${label}: ${audio.detail}`;
+  }
+  return audio.name;
+}


### PR DESCRIPTION
## Run Management UI

### What's included

**Pages:**
- **Dashboard** — weekly stats (runs, km, calories, avg pace) + recent completed runs list
- **NewRunPage** — full form: title, date/time, status, duration, notes, audio (music/podcast with subtypes)
- **PlannedRunsPage** — filterable planned runs list with complete/delete actions
- **RunDetailPage** — stats grid, inline title edit, delete with confirm modal
- **ProfilePage** — display name, weight, height, birth date form + sign out

**Components:**
- **BottomNav** — 4-tab navigation (Home, New Run, Planned, Profile) with active state
- CSS modules per page + `shared.module.css` for reusable card/page styles

**Utilities:**
- **api/client.ts** — typed API client with auth token injection, error handling
- **utils/format.ts** — duration, pace, date, calories, audio formatters
- **types/run.ts** + **types/profile.ts** — full type definitions

### Tests (21 files changed, ~2100 lines)
- BottomNav: 6 unit tests (tab rendering, active states)
- ProfilePage: 5 unit tests (loading, form fields, data population)
- format.ts: 12 unit tests (all formatters, edge cases)

### Notes
- Routes protected via `ProtectedRoute` wrapper
- API client uses `@aws-amplify/auth` for Cognito token
- Audio field matches backend structured format (music artist/playlist, podcast)
- Dashboard week starts Monday (ISO convention)
- No E2E tests yet — will add in follow-up PR