### PR TITLE
fix: profile save/fetch fails due to Decimal serialization

### DIFF
--- a/backend/data/profile.py
+++ b/backend/data/profile.py
@@ -3,15 +3,25 @@
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 from typing import Any
-
-from boto3.dynamodb.conditions import Key
 
 from data.table import get_table
 
 logger = logging.getLogger(__name__)
 
 SK_PROFILE = "PROFILE"
+
+
+def _convert_decimals(obj: Any) -> Any:
+    """Convert DynamoDB Decimal types to int/float for JSON serialization."""
+    if isinstance(obj, Decimal):
+        return int(obj) if obj == int(obj) else float(obj)
+    if isinstance(obj, dict):
+        return {k: _convert_decimals(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_convert_decimals(i) for i in obj]
+    return obj
 
 
 def get_profile(user_id: str) -> dict[str, Any] | None:
@@ -22,6 +32,7 @@ def get_profile(user_id: str) -> dict[str, Any] | None:
     if item:
         item.pop("userId", None)
         item.pop("sk", None)
+        item = _convert_decimals(item)
     return item
 
 
@@ -36,4 +47,4 @@ def put_profile(user_id: str, profile_data: dict[str, Any]) -> dict[str, Any]:
     table.put_item(Item=item)
     item.pop("userId", None)
     item.pop("sk", None)
-    return item
+    return _convert_decimals(item)

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -24,7 +24,12 @@ export function ProfilePage() {
         setHeightCm(profile.heightCm?.toString() ?? "");
         setBirthDate(profile.birthDate ?? "");
       })
-      .catch((err: Error) => setError(err.message))
+      .catch((err: unknown) => {
+        // 404 = no profile yet, just show empty form
+        if (err instanceof Error && err.message.includes("404")) return;
+        const message = err instanceof Error ? err.message : "Failed to load profile";
+        setError(message);
+      })
       .finally(() => setLoading(false));
   }, []);
 


### PR DESCRIPTION
## Bug Fix

**Problem:** After saving a profile (weight, height, etc.), fetching it back fails with a 500 error. The saved data is in DynamoDB but can't be returned.

**Root cause:** DynamoDB stores numbers as `Decimal` objects. `json.dumps()` can't serialize `Decimal`, so the Lambda handler crashes on GET after a successful PUT. The runs data layer had `_convert_decimals()` but it was never added to the profile data layer.

**Also fixed:** First-time users with no saved profile got a scary error message (404 treated as error). Now the frontend shows an empty form instead.

### Changes

**backend/data/profile.py**
- Added `_convert_decimals()` (same pattern as `data/runs.py`)
- Applied to both `get_profile` and `put_profile` return values
- Removed unused `Key` import

**frontend/src/pages/ProfilePage.tsx**
- 404 on GET /profile now silently shows empty form instead of error banner

### Tests
- All 10 backend profile tests pass
- All 5 frontend ProfilePage tests pass