### PR TITLE
feat: default map center on Kiryat Ono

### DIFF
--- a/frontend/src/__tests__/mapConfig.test.ts
+++ b/frontend/src/__tests__/mapConfig.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_CENTER, DEFAULT_ZOOM, TILE_STYLE } from "../components/Map/mapConfig";
+
+describe("mapConfig", () => {
+  it("defaults to Kiryat Ono coordinates [lng, lat]", () => {
+    expect(DEFAULT_CENTER).toEqual([34.8553, 32.0633]);
+  });
+
+  it("defaults to zoom level 15", () => {
+    expect(DEFAULT_ZOOM).toBe(15);
+  });
+
+  it("exports a valid tile style URL", () => {
+    expect(TILE_STYLE).toMatch(/^https:\/\//);
+  });
+});

--- a/frontend/src/components/Map/RouteMap.tsx
+++ b/frontend/src/components/Map/RouteMap.tsx
@@ -2,8 +2,7 @@ import { useRef, useEffect } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { Coordinate } from "../../types/run";
-
-const TILE_STYLE = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+import { TILE_STYLE } from "./mapConfig";
 const ROUTE_SOURCE_ID = "route-source";
 const ROUTE_LAYER_ID = "route-layer";
 

--- a/frontend/src/components/Map/RunMap.tsx
+++ b/frontend/src/components/Map/RunMap.tsx
@@ -3,11 +3,9 @@ import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { Coordinate } from "../../types/run";
 import { calculateRouteDistance, formatDistance } from "../../utils/distance";
+import { DEFAULT_CENTER, DEFAULT_ZOOM, TILE_STYLE } from "./mapConfig";
 import styles from "./RunMap.module.css";
 
-const TILE_STYLE = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
-const DEFAULT_CENTER: [number, number] = [34.7818, 32.0853]; // Tel Aviv [lng, lat]
-const DEFAULT_ZOOM = 13;
 const ROUTE_SOURCE_ID = "route-source";
 const ROUTE_LAYER_ID = "route-layer";
 

--- a/frontend/src/components/Map/mapConfig.ts
+++ b/frontend/src/components/Map/mapConfig.ts
@@ -1,0 +1,7 @@
+/** Default map center: Kiryat Ono, Israel [lng, lat] */
+export const DEFAULT_CENTER: [number, number] = [34.8553, 32.0633];
+
+/** Default zoom level */
+export const DEFAULT_ZOOM = 15;
+
+export const TILE_STYLE = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";


### PR DESCRIPTION
Sets default map center to Kiryat Ono, Israel (32.0633°N, 34.8553°E) at zoom 15.

Closes #14