### PR TITLE
feat: map labels in English

### DIFF
--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -15,6 +15,8 @@ beforeAll(() => {
       addLayer: vi.fn(),
       getSource: vi.fn(),
       fitBounds: vi.fn(),
+      getStyle: vi.fn().mockReturnValue({ layers: [] }),
+      setLayoutProperty: vi.fn(),
     }));
 
     const LngLatBounds = vi.fn().mockImplementation(() => ({

--- a/frontend/src/__tests__/NewRunPage.test.tsx
+++ b/frontend/src/__tests__/NewRunPage.test.tsx
@@ -11,6 +11,8 @@ beforeAll(() => {
       addSource: vi.fn(),
       addLayer: vi.fn(),
       getSource: vi.fn(),
+      getStyle: vi.fn().mockReturnValue({ layers: [] }),
+      setLayoutProperty: vi.fn(),
     }));
 
     const Marker = vi.fn().mockImplementation(() => {

--- a/frontend/src/__tests__/RouteMap.test.tsx
+++ b/frontend/src/__tests__/RouteMap.test.tsx
@@ -12,6 +12,8 @@ beforeAll(() => {
       addLayer: vi.fn(),
       getSource: vi.fn(),
       fitBounds: vi.fn(),
+      getStyle: vi.fn().mockReturnValue({ layers: [] }),
+      setLayoutProperty: vi.fn(),
     }));
 
     const LngLatBounds = vi.fn().mockImplementation(() => ({

--- a/frontend/src/__tests__/RunMap.test.tsx
+++ b/frontend/src/__tests__/RunMap.test.tsx
@@ -83,6 +83,8 @@ beforeAll(() => {
       getSource: vi.fn().mockReturnValue({
         setData: vi.fn(),
       }),
+      getStyle: vi.fn().mockReturnValue({ layers: [] }),
+      setLayoutProperty: vi.fn(),
     }));
 
     const Marker = vi.fn().mockImplementation(({ element }: { element?: HTMLDivElement } = {}) => {

--- a/frontend/src/__tests__/mapLabels.test.ts
+++ b/frontend/src/__tests__/mapLabels.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { setEnglishLabels } from "../utils/mapLabels";
+import type { Map as MaplibreMap } from "maplibre-gl";
+
+function createMockMap(layers: Record<string, unknown>[]): MaplibreMap {
+  return {
+    getStyle: vi.fn().mockReturnValue({ layers }),
+    setLayoutProperty: vi.fn(),
+  } as unknown as MaplibreMap;
+}
+
+describe("setEnglishLabels", () => {
+  it("sets text-field to coalesce name:en and name for symbol layers", () => {
+    const map = createMockMap([
+      { id: "place-city", type: "symbol", layout: { "text-field": "{name}" } },
+      { id: "road-label", type: "symbol", layout: { "text-field": ["get", "name"] } },
+    ]);
+
+    setEnglishLabels(map);
+
+    expect(map.setLayoutProperty).toHaveBeenCalledTimes(2);
+    expect(map.setLayoutProperty).toHaveBeenCalledWith("place-city", "text-field", [
+      "coalesce",
+      ["get", "name:en"],
+      ["get", "name"],
+    ]);
+    expect(map.setLayoutProperty).toHaveBeenCalledWith("road-label", "text-field", [
+      "coalesce",
+      ["get", "name:en"],
+      ["get", "name"],
+    ]);
+  });
+
+  it("skips non-symbol layers", () => {
+    const map = createMockMap([
+      { id: "road-fill", type: "fill", layout: {} },
+      { id: "road-line", type: "line", layout: {} },
+    ]);
+
+    setEnglishLabels(map);
+
+    expect(map.setLayoutProperty).not.toHaveBeenCalled();
+  });
+
+  it("skips symbol layers without text-field", () => {
+    const map = createMockMap([
+      { id: "icon-only", type: "symbol", layout: { "icon-image": "marker" } },
+    ]);
+
+    setEnglishLabels(map);
+
+    expect(map.setLayoutProperty).not.toHaveBeenCalled();
+  });
+
+  it("handles missing style gracefully", () => {
+    const map = {
+      getStyle: vi.fn().mockReturnValue(undefined),
+      setLayoutProperty: vi.fn(),
+    } as unknown as MaplibreMap;
+
+    expect(() => setEnglishLabels(map)).not.toThrow();
+    expect(map.setLayoutProperty).not.toHaveBeenCalled();
+  });
+
+  it("handles style with no layers gracefully", () => {
+    const map = createMockMap([]);
+
+    expect(() => setEnglishLabels(map)).not.toThrow();
+    expect(map.setLayoutProperty).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Map/RouteMap.tsx
+++ b/frontend/src/components/Map/RouteMap.tsx
@@ -3,6 +3,7 @@ import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { Coordinate } from "../../types/run";
 import { TILE_STYLE } from "./mapConfig";
+import { setEnglishLabels } from "../../utils/mapLabels";
 const ROUTE_SOURCE_ID = "route-source";
 const ROUTE_LAYER_ID = "route-layer";
 
@@ -30,6 +31,8 @@ export function RouteMap({ route, height = "200px" }: RouteMapProps) {
     mapRef.current = map;
 
     map.on("load", () => {
+      setEnglishLabels(map);
+
       map.addSource(ROUTE_SOURCE_ID, {
         type: "geojson",
         data: {

--- a/frontend/src/components/Map/RunMap.tsx
+++ b/frontend/src/components/Map/RunMap.tsx
@@ -4,6 +4,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import type { Coordinate } from "../../types/run";
 import { calculateRouteDistance, formatDistance } from "../../utils/distance";
 import { DEFAULT_CENTER, DEFAULT_ZOOM, TILE_STYLE } from "./mapConfig";
+import { setEnglishLabels } from "../../utils/mapLabels";
 import styles from "./RunMap.module.css";
 
 const ROUTE_SOURCE_ID = "route-source";
@@ -213,6 +214,8 @@ export function RunMap({ onRouteChange }: RunMapProps) {
     mapRef.current = map;
 
     map.on("load", () => {
+      setEnglishLabels(map);
+
       map.addSource(ROUTE_SOURCE_ID, {
         type: "geojson",
         data: {

--- a/frontend/src/utils/mapLabels.ts
+++ b/frontend/src/utils/mapLabels.ts
@@ -1,0 +1,21 @@
+import type { Map as MaplibreMap } from "maplibre-gl";
+
+/**
+ * Switches all symbol layers' text-field to prefer English names,
+ * falling back to the default name when English is unavailable.
+ * Works with OpenMapTiles-based styles (e.g. CARTO Positron).
+ */
+export function setEnglishLabels(map: MaplibreMap): void {
+  const style = map.getStyle();
+  if (!style?.layers) return;
+
+  for (const layer of style.layers) {
+    if (layer.type === "symbol" && layer.layout?.["text-field"]) {
+      map.setLayoutProperty(layer.id, "text-field", [
+        "coalesce",
+        ["get", "name:en"],
+        ["get", "name"],
+      ]);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `setEnglishLabels()` utility that switches all symbol layers' `text-field` to prefer `name:en` with fallback to `name`
- Called on map load in both `RunMap` and `RouteMap` components
- Fixes Hebrew-default labels when viewing maps centered on Israel

## Test plan
- [x] Unit tests for `setEnglishLabels` covering symbol layers, non-symbol layers, missing text-field, and edge cases
- [x] Updated maplibre-gl mocks in all 4 test files to include `getStyle`/`setLayoutProperty`
- [x] All 58 tests pass (`npx vitest run`)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)