### PR TITLE
feat: remove individual waypoints after placement

### DIFF
--- a/frontend/src/__tests__/RunMap.test.tsx
+++ b/frontend/src/__tests__/RunMap.test.tsx
@@ -1,26 +1,98 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 import { RunMap } from "../components/Map/RunMap";
+
+type MapEventHandler = (e: unknown) => void;
+type MarkerEventHandler = () => void;
+
+let mapClickHandler: MapEventHandler | null = null;
+let mapLoadHandler: MapEventHandler | null = null;
+const createdMarkers: Array<{
+  element: HTMLDivElement;
+  marker: ReturnType<typeof createMockMarker>;
+  dragStartHandler?: MarkerEventHandler;
+  dragEndHandler?: MarkerEventHandler;
+}> = [];
+const createdPopups: Array<{
+  popup: ReturnType<typeof createMockPopup>;
+  content?: HTMLElement;
+  lngLat?: { lng: number; lat: number };
+}> = [];
+
+function createMockMarker(element?: HTMLDivElement) {
+  const el = element ?? document.createElement("div");
+  const lngLat = { lng: 0, lat: 0 };
+  const eventHandlers: Record<string, MarkerEventHandler> = {};
+
+  const marker = {
+    setLngLat: vi.fn().mockImplementation((ll: { lng: number; lat: number } | [number, number]) => {
+      if (Array.isArray(ll)) {
+        lngLat.lng = ll[0];
+        lngLat.lat = ll[1];
+      } else {
+        lngLat.lng = ll.lng;
+        lngLat.lat = ll.lat;
+      }
+      return marker;
+    }),
+    addTo: vi.fn().mockReturnThis(),
+    on: vi.fn().mockImplementation((event: string, handler: MarkerEventHandler) => {
+      eventHandlers[event] = handler;
+      return marker;
+    }),
+    remove: vi.fn(),
+    getLngLat: vi.fn().mockImplementation(() => ({ ...lngLat })),
+    getElement: vi.fn().mockReturnValue(el),
+    _eventHandlers: eventHandlers,
+    _element: el,
+  };
+  return marker;
+}
+
+function createMockPopup() {
+  const popup = {
+    setDOMContent: vi.fn().mockImplementation((content: HTMLElement) => {
+      const entry = createdPopups.find((p) => p.popup === popup);
+      if (entry) entry.content = content;
+      return popup;
+    }),
+    setLngLat: vi.fn().mockImplementation((ll: { lng: number; lat: number }) => {
+      const entry = createdPopups.find((p) => p.popup === popup);
+      if (entry) entry.lngLat = ll;
+      return popup;
+    }),
+    addTo: vi.fn().mockReturnThis(),
+    remove: vi.fn(),
+  };
+  createdPopups.push({ popup });
+  return popup;
+}
 
 beforeAll(() => {
   vi.mock("maplibre-gl", () => {
     const Map = vi.fn().mockImplementation(() => ({
-      on: vi.fn(),
+      on: vi.fn().mockImplementation((event: string, handler: MapEventHandler) => {
+        if (event === "click") mapClickHandler = handler;
+        if (event === "load") {
+          mapLoadHandler = handler;
+        }
+      }),
       remove: vi.fn(),
       addSource: vi.fn(),
       addLayer: vi.fn(),
-      getSource: vi.fn(),
+      getSource: vi.fn().mockReturnValue({
+        setData: vi.fn(),
+      }),
     }));
 
-    const Marker = vi.fn().mockImplementation(() => {
-      const marker = {
-        setLngLat: vi.fn().mockReturnThis(),
-        addTo: vi.fn().mockReturnThis(),
-        on: vi.fn().mockReturnThis(),
-        remove: vi.fn(),
-        getLngLat: vi.fn().mockReturnValue({ lng: 0, lat: 0 }),
-      };
+    const Marker = vi.fn().mockImplementation(({ element }: { element?: HTMLDivElement } = {}) => {
+      const marker = createMockMarker(element);
+      createdMarkers.push({ element: element ?? document.createElement("div"), marker });
       return marker;
+    });
+
+    const Popup = vi.fn().mockImplementation(() => {
+      return createMockPopup();
     });
 
     const LngLatBounds = vi.fn().mockImplementation(() => ({
@@ -28,13 +100,35 @@ beforeAll(() => {
     }));
 
     return {
-      default: { Map, Marker, LngLatBounds },
+      default: { Map, Marker, Popup, LngLatBounds },
       Map,
       Marker,
+      Popup,
       LngLatBounds,
     };
   });
 });
+
+beforeEach(() => {
+  mapClickHandler = null;
+  mapLoadHandler = null;
+  createdMarkers.length = 0;
+  createdPopups.length = 0;
+});
+
+function triggerMapLoad() {
+  if (mapLoadHandler) {
+    act(() => {
+      (mapLoadHandler as MapEventHandler)({});
+    });
+  }
+}
+
+function addWaypointAt(lng: number, lat: number) {
+  act(() => {
+    (mapClickHandler as MapEventHandler)({ lngLat: { lng, lat } });
+  });
+}
 
 describe("RunMap", () => {
   it("renders without crashing", () => {
@@ -58,5 +152,144 @@ describe("RunMap", () => {
     render(<RunMap />);
     expect(screen.getByRole("button", { name: /undo/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /clear/i })).toBeDisabled();
+  });
+
+  it("creates marker elements with pointer cursor and hover class", () => {
+    render(<RunMap />);
+    triggerMapLoad();
+    addWaypointAt(34.78, 32.08);
+
+    const markerEl = createdMarkers[0].element;
+    expect(markerEl.style.cursor).toBe("pointer");
+    expect(markerEl.className).toBe("waypoint-marker");
+    expect(markerEl.style.transition).toContain("transform");
+  });
+
+  it("scales marker on hover", () => {
+    render(<RunMap />);
+    triggerMapLoad();
+    addWaypointAt(34.78, 32.08);
+
+    const markerEl = createdMarkers[0].element;
+    fireEvent.mouseEnter(markerEl);
+    expect(markerEl.style.transform).toBe("scale(1.2)");
+
+    fireEvent.mouseLeave(markerEl);
+    expect(markerEl.style.transform).toBe("scale(1)");
+  });
+
+  it("shows remove popup when marker is clicked", () => {
+    render(<RunMap />);
+    triggerMapLoad();
+    addWaypointAt(34.78, 32.08);
+
+    const markerEl = createdMarkers[0].element;
+    fireEvent.click(markerEl);
+
+    expect(createdPopups.length).toBe(1);
+    expect(createdPopups[0].popup.addTo).toHaveBeenCalled();
+    expect(createdPopups[0].content?.textContent).toBe("Remove waypoint");
+  });
+
+  it("does not show popup after drag", () => {
+    render(<RunMap />);
+    triggerMapLoad();
+    addWaypointAt(34.78, 32.08);
+
+    const markerMock = createdMarkers[0].marker;
+    // Simulate drag
+    const dragStartHandler = markerMock._eventHandlers["dragstart"];
+    act(() => dragStartHandler());
+
+    // Click after drag should be suppressed
+    const markerEl = createdMarkers[0].element;
+    fireEvent.click(markerEl);
+
+    expect(createdPopups.length).toBe(0);
+  });
+
+  it("removes waypoint when remove button is clicked", () => {
+    const onRouteChange = vi.fn();
+    render(<RunMap onRouteChange={onRouteChange} />);
+    triggerMapLoad();
+
+    addWaypointAt(34.78, 32.08);
+    addWaypointAt(34.79, 32.09);
+    addWaypointAt(34.80, 32.10);
+
+    expect(createdMarkers.length).toBe(3);
+
+    // Click the second marker to show popup
+    const markerEl = createdMarkers[1].element;
+    fireEvent.click(markerEl);
+
+    // Click the remove button in the popup
+    const removeBtn = createdPopups[0].content as HTMLButtonElement;
+    fireEvent.click(removeBtn);
+
+    // Second marker should be removed
+    expect(createdMarkers[1].marker.remove).toHaveBeenCalled();
+    // onRouteChange called with remaining coords
+    const lastCall = onRouteChange.mock.calls[onRouteChange.mock.calls.length - 1];
+    expect(lastCall[0]).toHaveLength(2);
+  });
+
+  it("renumbers markers after removal", () => {
+    render(<RunMap />);
+    triggerMapLoad();
+
+    addWaypointAt(34.78, 32.08);
+    addWaypointAt(34.79, 32.09);
+    addWaypointAt(34.80, 32.10);
+
+    expect(createdMarkers[0].element.textContent).toBe("1");
+    expect(createdMarkers[1].element.textContent).toBe("2");
+    expect(createdMarkers[2].element.textContent).toBe("3");
+
+    // Remove the first waypoint
+    fireEvent.click(createdMarkers[0].element);
+    const removeBtn = createdPopups[0].content as HTMLButtonElement;
+    fireEvent.click(removeBtn);
+
+    // Remaining markers should be renumbered
+    expect(createdMarkers[1].element.textContent).toBe("1");
+    expect(createdMarkers[2].element.textContent).toBe("2");
+  });
+
+  it("removes any waypoint not just the last one", () => {
+    render(<RunMap />);
+    triggerMapLoad();
+
+    addWaypointAt(34.78, 32.08);
+    addWaypointAt(34.79, 32.09);
+    addWaypointAt(34.80, 32.10);
+
+    // Remove middle waypoint
+    fireEvent.click(createdMarkers[1].element);
+    const removeBtn = createdPopups[0].content as HTMLButtonElement;
+    fireEvent.click(removeBtn);
+
+    expect(createdMarkers[1].marker.remove).toHaveBeenCalled();
+    // First and third markers should remain
+    expect(createdMarkers[0].marker.remove).not.toHaveBeenCalled();
+    expect(createdMarkers[2].marker.remove).not.toHaveBeenCalled();
+  });
+
+  it("closes previous popup when opening a new one", () => {
+    render(<RunMap />);
+    triggerMapLoad();
+
+    addWaypointAt(34.78, 32.08);
+    addWaypointAt(34.79, 32.09);
+
+    // Click first marker
+    fireEvent.click(createdMarkers[0].element);
+    expect(createdPopups.length).toBe(1);
+
+    // Click second marker
+    fireEvent.click(createdMarkers[1].element);
+    expect(createdPopups.length).toBe(2);
+    // First popup should have been removed
+    expect(createdPopups[0].popup.remove).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/Map/RunMap.tsx
+++ b/frontend/src/components/Map/RunMap.tsx
@@ -20,6 +20,8 @@ export function RunMap({ onRouteChange }: RunMapProps) {
   const mapRef = useRef<maplibregl.Map | null>(null);
   const markersRef = useRef<maplibregl.Marker[]>([]);
   const coordsRef = useRef<Coordinate[]>([]);
+  const popupRef = useRef<maplibregl.Popup | null>(null);
+  const draggedRef = useRef(false);
   const [distance, setDistance] = useState(0);
   const [pointCount, setPointCount] = useState(0);
 
@@ -48,6 +50,7 @@ export function RunMap({ onRouteChange }: RunMapProps) {
 
   const createMarkerElement = useCallback((index: number): HTMLDivElement => {
     const el = document.createElement("div");
+    el.className = "waypoint-marker";
     el.style.width = "28px";
     el.style.height = "28px";
     el.style.borderRadius = "50%";
@@ -60,11 +63,75 @@ export function RunMap({ onRouteChange }: RunMapProps) {
     el.style.color = "#ffffff";
     el.style.fontSize = "12px";
     el.style.fontWeight = "700";
-    el.style.cursor = "grab";
+    el.style.cursor = "pointer";
     el.style.touchAction = "none";
+    el.style.transition = "transform 0.15s ease, box-shadow 0.15s ease";
     el.textContent = String(index + 1);
+
+    el.addEventListener("mouseenter", () => {
+      el.style.transform = "scale(1.2)";
+      el.style.boxShadow = "0 3px 10px rgba(0,0,0,0.4)";
+    });
+    el.addEventListener("mouseleave", () => {
+      el.style.transform = "scale(1)";
+      el.style.boxShadow = "0 2px 6px rgba(0,0,0,0.3)";
+    });
+
     return el;
   }, []);
+
+  const removeWaypoint = useCallback(
+    (index: number) => {
+      const map = mapRef.current;
+      if (!map) return;
+
+      popupRef.current?.remove();
+      popupRef.current = null;
+
+      markersRef.current[index].remove();
+      markersRef.current = markersRef.current.filter((_, i) => i !== index);
+      coordsRef.current = coordsRef.current.filter((_, i) => i !== index);
+
+      markersRef.current.forEach((m, i) => {
+        const el = m.getElement();
+        el.textContent = String(i + 1);
+      });
+
+      updateRoute();
+    },
+    [updateRoute]
+  );
+
+  const showRemovePopup = useCallback(
+    (marker: maplibregl.Marker, index: number) => {
+      const map = mapRef.current;
+      if (!map) return;
+
+      popupRef.current?.remove();
+
+      const btn = document.createElement("button");
+      btn.textContent = "Remove waypoint";
+      btn.setAttribute("data-testid", "remove-waypoint-btn");
+      btn.style.cssText =
+        "padding:6px 12px;border:none;border-radius:6px;background:#ef4444;color:#fff;font-size:13px;font-weight:600;cursor:pointer;white-space:nowrap;";
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const currentIndex = markersRef.current.indexOf(marker);
+        if (currentIndex !== -1) {
+          removeWaypoint(currentIndex);
+        }
+      });
+
+      const popup = new maplibregl.Popup({ offset: 20, closeButton: false })
+        .setDOMContent(btn)
+        .setLngLat(marker.getLngLat())
+        .addTo(map);
+
+      popupRef.current = popup;
+    },
+    [removeWaypoint]
+  );
 
   const addWaypoint = useCallback(
     (lngLat: maplibregl.LngLat) => {
@@ -75,12 +142,17 @@ export function RunMap({ onRouteChange }: RunMapProps) {
       const index = coordsRef.current.length;
       coordsRef.current = [...coordsRef.current, coord];
 
+      const el = createMarkerElement(index);
       const marker = new maplibregl.Marker({
-        element: createMarkerElement(index),
+        element: el,
         draggable: true,
       })
         .setLngLat(lngLat)
         .addTo(map);
+
+      marker.on("dragstart", () => {
+        draggedRef.current = true;
+      });
 
       marker.on("dragend", () => {
         const pos = marker.getLngLat();
@@ -93,10 +165,22 @@ export function RunMap({ onRouteChange }: RunMapProps) {
         }
       });
 
+      el.addEventListener("click", (e) => {
+        e.stopPropagation();
+        if (draggedRef.current) {
+          draggedRef.current = false;
+          return;
+        }
+        const currentIndex = markersRef.current.indexOf(marker);
+        if (currentIndex !== -1) {
+          showRemovePopup(marker, currentIndex);
+        }
+      });
+
       markersRef.current = [...markersRef.current, marker];
       updateRoute();
     },
-    [createMarkerElement, updateRoute]
+    [createMarkerElement, showRemovePopup, updateRoute]
   );
 
   const handleUndo = useCallback(() => {


### PR DESCRIPTION
## Summary
- Click any placed waypoint marker to show a "Remove waypoint" popup
- Removes the waypoint, recalculates route and distance with remaining points
- Renumbers remaining markers after removal (works for any waypoint, not just the last)
- Visual feedback: `cursor:pointer` and scale-up effect on marker hover
- Drag-vs-click detection prevents false popup triggers

Closes #18

## Test plan
- [x] All 12 RunMap tests pass (8 new tests for removal, hover, popup, renumbering)
- [x] Full test suite passes (61 tests, 10 files)
- [ ] Manual: place 3+ waypoints, click middle one, confirm popup appears, click "Remove waypoint"
- [ ] Manual: verify remaining markers renumber correctly and route/distance update
- [ ] Manual: drag a marker and verify popup does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)