### PR TITLE
feat: larger map display on screen

### DIFF
--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -115,7 +115,7 @@ export function RunDetailPage() {
     <div className={shared.page}>
       {run.route && run.route.length >= 2 ? (
         <div className={styles.mapArea}>
-          <RouteMap route={run.route} height="300px" />
+          <RouteMap route={run.route} height="100%" />
         </div>
       ) : (
         <div className={styles.mapPlaceholder}>No route recorded</div>

--- a/frontend/src/styles/NewRunPage.module.css
+++ b/frontend/src/styles/NewRunPage.module.css
@@ -22,8 +22,16 @@
 }
 
 .mapArea {
-  height: 300px;
+  height: 50vh;
+  min-height: 300px;
   position: relative;
+}
+
+@media (max-width: 768px) {
+  .mapArea {
+    height: 40vh;
+    min-height: 250px;
+  }
 }
 
 .form {

--- a/frontend/src/styles/RunDetailPage.module.css
+++ b/frontend/src/styles/RunDetailPage.module.css
@@ -1,5 +1,13 @@
 .mapArea {
-  height: 300px;
+  height: 50vh;
+  min-height: 300px;
+}
+
+@media (max-width: 768px) {
+  .mapArea {
+    height: 40vh;
+    min-height: 250px;
+  }
 }
 
 .mapPlaceholder {


### PR DESCRIPTION
## Summary
- Increase map height from fixed 300px to 50vh (desktop) / 40vh (mobile) on NewRunPage and RunDetailPage
- Add responsive CSS media queries at 768px breakpoint with min-height fallbacks
- RouteMap dashboard preview stays at default 200px

## Test plan
- [x] All 53 Vitest unit tests pass
- [ ] Playwright e2e skipped (requires running server)
- [ ] Manual: verify map is larger on desktop and mobile viewports
- [ ] Manual: verify form fields below map are still scrollable/accessible

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)