### PR TITLE
feat: mandatory profile fields (email, displayName, height, weight) and remove birthDate

### DIFF
--- a/backend/handlers/profile.py
+++ b/backend/handlers/profile.py
@@ -60,7 +60,7 @@ def _put_profile(user_id: str, event: dict[str, Any]) -> dict[str, Any]:
         return _error(400, "; ".join(errors))
 
     profile_data = {}
-    for field in ("weightKg", "heightCm", "birthDate", "displayName"):
+    for field in ("email", "displayName", "heightCm", "weightKg"):
         if field in body:
             profile_data[field] = body[field]
 

--- a/backend/handlers/utils/validation.py
+++ b/backend/handlers/utils/validation.py
@@ -8,7 +8,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-ISO_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 ISO_DATETIME_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
 ULID_PATTERN = re.compile(r"^[0-9A-Z]{26}$")
 
@@ -26,21 +26,26 @@ def validate_profile(body: dict[str, Any]) -> list[str]:
     """Validate profile update payload. Returns list of error messages."""
     errors: list[str] = []
 
-    if "weightKg" in body:
-        if not isinstance(body["weightKg"], (int, float)) or body["weightKg"] <= 0:
-            errors.append("weightKg must be a positive number")
+    required_fields = ("email", "displayName", "heightCm", "weightKg")
+    for field in required_fields:
+        if field not in body:
+            errors.append(f"{field} is required")
+
+    if "email" in body:
+        if not isinstance(body["email"], str) or not EMAIL_PATTERN.match(body["email"]):
+            errors.append("email must be a valid email address")
+
+    if "displayName" in body:
+        if not isinstance(body["displayName"], str) or len(body["displayName"]) > 100:
+            errors.append("displayName must be a string of 100 characters or less")
 
     if "heightCm" in body:
         if not isinstance(body["heightCm"], (int, float)) or body["heightCm"] <= 0:
             errors.append("heightCm must be a positive number")
 
-    if "birthDate" in body:
-        if not isinstance(body["birthDate"], str) or not ISO_DATE_PATTERN.match(body["birthDate"]):
-            errors.append("birthDate must be a valid ISO date (YYYY-MM-DD)")
-
-    if "displayName" in body:
-        if not isinstance(body["displayName"], str) or len(body["displayName"]) > 100:
-            errors.append("displayName must be a string of 100 characters or less")
+    if "weightKg" in body:
+        if not isinstance(body["weightKg"], (int, float)) or body["weightKg"] <= 0:
+            errors.append("weightKg must be a positive number")
 
     return errors
 

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -22,9 +22,17 @@ def _make_event(method: str = "GET", body: dict | None = None, user_id: str = "t
     return event
 
 
+VALID_PROFILE = {
+    "email": "user@example.com",
+    "displayName": "Test User",
+    "heightCm": 175,
+    "weightKg": 70,
+}
+
+
 @patch("handlers.profile.get_profile")
 def test_get_profile_success(mock_get: object) -> None:
-    mock_get.return_value = {"weightKg": 70, "heightCm": 175, "birthDate": "1990-01-01"}
+    mock_get.return_value = {"email": "u@example.com", "weightKg": 70, "heightCm": 175}
     response = handler(_make_event("GET"), None)
     assert response["statusCode"] == 200
     body = json.loads(response["body"])
@@ -40,16 +48,17 @@ def test_get_profile_not_found(mock_get: object) -> None:
 
 @patch("handlers.profile.put_profile")
 def test_put_profile_success(mock_put: object) -> None:
-    mock_put.return_value = {"weightKg": 75, "heightCm": 180}
-    response = handler(_make_event("PUT", {"weightKg": 75, "heightCm": 180}), None)
+    mock_put.return_value = VALID_PROFILE
+    response = handler(_make_event("PUT", VALID_PROFILE), None)
     assert response["statusCode"] == 200
 
 
 def test_put_profile_invalid_weight() -> None:
-    response = handler(_make_event("PUT", {"weightKg": -10}), None)
+    body = {**VALID_PROFILE, "weightKg": -10}
+    response = handler(_make_event("PUT", body), None)
     assert response["statusCode"] == 400
-    body = json.loads(response["body"])
-    assert "weightKg" in body["error"]
+    resp_body = json.loads(response["body"])
+    assert "weightKg" in resp_body["error"]
 
 
 def test_put_profile_invalid_json() -> None:
@@ -81,15 +90,79 @@ def test_options_returns_200() -> None:
     assert response["statusCode"] == 200
 
 
-def test_put_profile_invalid_birth_date() -> None:
-    response = handler(_make_event("PUT", {"birthDate": "not-a-date"}), None)
-    assert response["statusCode"] == 400
-
-
 @patch("handlers.profile.put_profile")
 def test_put_profile_sets_updated_at(mock_put: object) -> None:
-    mock_put.return_value = {"weightKg": 70}
-    handler(_make_event("PUT", {"weightKg": 70}), None)
+    mock_put.return_value = VALID_PROFILE
+    handler(_make_event("PUT", VALID_PROFILE), None)
     call_args = mock_put.call_args
     profile_data = call_args[0][1]
     assert "updatedAt" in profile_data
+
+
+def test_put_profile_missing_email() -> None:
+    body = {k: v for k, v in VALID_PROFILE.items() if k != "email"}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "email is required" in json.loads(response["body"])["error"]
+
+
+def test_put_profile_missing_display_name() -> None:
+    body = {k: v for k, v in VALID_PROFILE.items() if k != "displayName"}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "displayName is required" in json.loads(response["body"])["error"]
+
+
+def test_put_profile_missing_height() -> None:
+    body = {k: v for k, v in VALID_PROFILE.items() if k != "heightCm"}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "heightCm is required" in json.loads(response["body"])["error"]
+
+
+def test_put_profile_missing_weight() -> None:
+    body = {k: v for k, v in VALID_PROFILE.items() if k != "weightKg"}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "weightKg is required" in json.loads(response["body"])["error"]
+
+
+def test_put_profile_invalid_email_format() -> None:
+    body = {**VALID_PROFILE, "email": "not-an-email"}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "email" in json.loads(response["body"])["error"]
+
+
+def test_put_profile_invalid_email_empty() -> None:
+    body = {**VALID_PROFILE, "email": ""}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+
+
+def test_put_profile_birth_date_ignored() -> None:
+    """birthDate field should not be stored even if sent."""
+    body = {**VALID_PROFILE, "birthDate": "1990-01-01"}
+    with patch("handlers.profile.put_profile") as mock_put:
+        mock_put.return_value = VALID_PROFILE
+        handler(_make_event("PUT", body), None)
+        profile_data = mock_put.call_args[0][1]
+        assert "birthDate" not in profile_data
+
+
+@patch("handlers.profile.put_profile")
+def test_put_profile_email_stored(mock_put: object) -> None:
+    mock_put.return_value = VALID_PROFILE
+    handler(_make_event("PUT", VALID_PROFILE), None)
+    profile_data = mock_put.call_args[0][1]
+    assert profile_data["email"] == "user@example.com"
+
+
+def test_put_profile_missing_all_required() -> None:
+    response = handler(_make_event("PUT", {}), None)
+    assert response["statusCode"] == 400
+    error = json.loads(response["body"])["error"]
+    assert "email is required" in error
+    assert "displayName is required" in error
+    assert "heightCm is required" in error
+    assert "weightKg is required" in error

--- a/backend/tests/test_profile_data.py
+++ b/backend/tests/test_profile_data.py
@@ -61,7 +61,7 @@ def test_converted_result_is_json_serializable() -> None:
         "weightKg": Decimal("75"),
         "heightCm": Decimal("180.5"),
         "displayName": "Test User",
-        "birthDate": "1990-01-01",
+        "email": "user@example.com",
     }
     result = _convert_decimals(data)
     # This would raise TypeError if Decimals leaked through
@@ -166,7 +166,7 @@ def test_handler_get_profile_with_decimal_response_is_valid_json(mock_get: Magic
         "weightKg": 80,
         "heightCm": 175,
         "displayName": "Test",
-        "birthDate": "1990-01-01",
+        "email": "test@example.com",
     }
     event = {
         "httpMethod": "GET",

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ProfilePage } from "../pages/ProfilePage";
@@ -10,14 +10,16 @@ vi.mock("../auth/AuthProvider", () => ({
   }),
 }));
 
+const mockUpdateProfile = vi.fn().mockResolvedValue({});
+
 vi.mock("../api/client", () => ({
   getProfile: vi.fn().mockResolvedValue({
+    email: "test@example.com",
     displayName: "Test User",
     weightKg: 75,
     heightCm: 180,
-    birthDate: "1990-01-15",
   }),
-  updateProfile: vi.fn().mockResolvedValue({}),
+  updateProfile: (...args: unknown[]) => mockUpdateProfile(...args),
 }));
 
 function renderPage() {
@@ -31,6 +33,7 @@ function renderPage() {
 describe("ProfilePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUpdateProfile.mockResolvedValue({});
   });
 
   it("shows loading state initially", () => {
@@ -41,21 +44,29 @@ describe("ProfilePage", () => {
   it("renders form fields after loading", async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByLabelText("Display Name")).toBeInTheDocument();
+      expect(screen.getByLabelText("Email *")).toBeInTheDocument();
     });
-    expect(screen.getByLabelText("Weight (kg)")).toBeInTheDocument();
-    expect(screen.getByLabelText("Height (cm)")).toBeInTheDocument();
-    expect(screen.getByLabelText("Birth Date")).toBeInTheDocument();
+    expect(screen.getByLabelText("Display Name *")).toBeInTheDocument();
+    expect(screen.getByLabelText("Weight (kg) *")).toBeInTheDocument();
+    expect(screen.getByLabelText("Height (cm) *")).toBeInTheDocument();
+  });
+
+  it("does not render birth date field", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Email *")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Birth Date")).not.toBeInTheDocument();
   });
 
   it("populates form with loaded profile data", async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByLabelText("Display Name")).toHaveValue("Test User");
+      expect(screen.getByLabelText("Email *")).toHaveValue("test@example.com");
     });
-    expect(screen.getByLabelText("Weight (kg)")).toHaveValue(75);
-    expect(screen.getByLabelText("Height (cm)")).toHaveValue(180);
-    expect(screen.getByLabelText("Birth Date")).toHaveValue("1990-01-15");
+    expect(screen.getByLabelText("Display Name *")).toHaveValue("Test User");
+    expect(screen.getByLabelText("Weight (kg) *")).toHaveValue(75);
+    expect(screen.getByLabelText("Height (cm) *")).toHaveValue(180);
   });
 
   it("renders save button", async () => {
@@ -69,6 +80,33 @@ describe("ProfilePage", () => {
     renderPage();
     await waitFor(() => {
       expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+  });
+
+  it("marks all fields as required", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Email *")).toBeRequired();
+    });
+    expect(screen.getByLabelText("Display Name *")).toBeRequired();
+    expect(screen.getByLabelText("Height (cm) *")).toBeRequired();
+    expect(screen.getByLabelText("Weight (kg) *")).toBeRequired();
+  });
+
+  it("shows validation error for invalid email on save", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Email *")).toBeInTheDocument();
+    });
+
+    const emailInput = screen.getByLabelText("Email *");
+    fireEvent.change(emailInput, { target: { value: "not-an-email" } });
+
+    const form = screen.getByText("Save Profile").closest("form") as HTMLFormElement;
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(screen.getByText("Please enter a valid email address")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -5,12 +5,14 @@ import type { Profile } from "../types/profile";
 import shared from "../styles/shared.module.css";
 import styles from "../styles/ProfilePage.module.css";
 
+const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
 export function ProfilePage() {
   const { signOut } = useAuth();
+  const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [weightKg, setWeightKg] = useState("");
   const [heightCm, setHeightCm] = useState("");
-  const [birthDate, setBirthDate] = useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -19,10 +21,10 @@ export function ProfilePage() {
   useEffect(() => {
     getProfile()
       .then((profile) => {
+        setEmail(profile.email ?? "");
         setDisplayName(profile.displayName ?? "");
         setWeightKg(profile.weightKg?.toString() ?? "");
         setHeightCm(profile.heightCm?.toString() ?? "");
-        setBirthDate(profile.birthDate ?? "");
       })
       .catch((err: unknown) => {
         // 404 = no profile yet, just show empty form
@@ -33,17 +35,36 @@ export function ProfilePage() {
       .finally(() => setLoading(false));
   }, []);
 
+  function validate(): string | null {
+    if (!email.trim()) return "Email is required";
+    if (!EMAIL_REGEX.test(email.trim())) return "Please enter a valid email address";
+    if (!displayName.trim()) return "Display name is required";
+    if (!heightCm) return "Height is required";
+    if (Number(heightCm) <= 0) return "Height must be a positive number";
+    if (!weightKg) return "Weight is required";
+    if (Number(weightKg) <= 0) return "Weight must be a positive number";
+    return null;
+  }
+
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
     setSaving(true);
     setError(null);
     setSuccess(false);
 
-    const data: Profile = {};
-    if (displayName.trim()) data.displayName = displayName.trim();
-    if (weightKg) data.weightKg = Number(weightKg);
-    if (heightCm) data.heightCm = Number(heightCm);
-    if (birthDate) data.birthDate = birthDate;
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      setSaving(false);
+      return;
+    }
+
+    const data: Profile = {
+      email: email.trim(),
+      displayName: displayName.trim(),
+      heightCm: Number(heightCm),
+      weightKg: Number(weightKg),
+    };
 
     try {
       await updateProfile(data);
@@ -75,18 +96,43 @@ export function ProfilePage() {
         {success && <div className={styles.success}>Profile saved!</div>}
 
         <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="displayName">Display Name</label>
+          <label className={shared.formLabel} htmlFor="email">Email *</label>
+          <input
+            id="email"
+            className={shared.formInput}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="displayName">Display Name *</label>
           <input
             id="displayName"
             className={shared.formInput}
             type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
+            required
           />
         </div>
 
         <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="weightKg">Weight (kg)</label>
+          <label className={shared.formLabel} htmlFor="heightCm">Height (cm) *</label>
+          <input
+            id="heightCm"
+            className={shared.formInput}
+            type="number"
+            value={heightCm}
+            onChange={(e) => setHeightCm(e.target.value)}
+            required
+          />
+        </div>
+
+        <div className={shared.formGroup}>
+          <label className={shared.formLabel} htmlFor="weightKg">Weight (kg) *</label>
           <input
             id="weightKg"
             className={shared.formInput}
@@ -94,28 +140,7 @@ export function ProfilePage() {
             step="0.1"
             value={weightKg}
             onChange={(e) => setWeightKg(e.target.value)}
-          />
-        </div>
-
-        <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="heightCm">Height (cm)</label>
-          <input
-            id="heightCm"
-            className={shared.formInput}
-            type="number"
-            value={heightCm}
-            onChange={(e) => setHeightCm(e.target.value)}
-          />
-        </div>
-
-        <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="birthDate">Birth Date</label>
-          <input
-            id="birthDate"
-            className={shared.formInput}
-            type="date"
-            value={birthDate}
-            onChange={(e) => setBirthDate(e.target.value)}
+            required
           />
         </div>
 

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -1,7 +1,7 @@
 export interface Profile {
-  weightKg?: number;
-  heightCm?: number;
-  birthDate?: string;
-  displayName?: string;
+  email: string;
+  displayName: string;
+  heightCm: number;
+  weightKg: number;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
- Makes `email`, `displayName`, `heightCm`, `weightKg` required profile fields with backend validation
- Adds email format validation (backend regex + frontend)
- Removes `birthDate` field entirely (backend handler, validation, frontend form, types)
- All fields marked required in the frontend form with client-side validation

## Test plan
- [x] Backend: 58 tests pass (`pytest -v`) — includes new tests for missing required fields, invalid email, birthDate rejection
- [x] Frontend: 56 tests pass (`vitest run`) — includes new tests for required field indicators, email validation, no birth date field

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)