### PR TITLE
feat: GET /stats API endpoint

### DIFF
--- a/backend/data/runs.py
+++ b/backend/data/runs.py
@@ -67,6 +67,23 @@ def list_runs(user_id: str) -> list[dict[str, Any]]:
     return [_strip_keys(dict(item)) for item in response.get("Items", [])]
 
 
+def list_all_runs(user_id: str) -> list[dict[str, Any]]:
+    """List all runs for a user with full pagination. Returns all items."""
+    table = get_table()
+    items: list[dict[str, Any]] = []
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("userId").eq(user_id) & Key("sk").begins_with(SK_PREFIX),
+    }
+    while True:
+        response = table.query(**kwargs)
+        items.extend(response.get("Items", []))
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        kwargs["ExclusiveStartKey"] = last_key
+    return [_strip_keys(dict(item)) for item in items]
+
+
 def update_run(user_id: str, run_id: str, update_data: dict[str, Any]) -> dict[str, Any] | None:
     """Update an existing run record. Returns updated item or None if not found."""
     table = get_table()

--- a/backend/handlers/stats.py
+++ b/backend/handlers/stats.py
@@ -1,0 +1,240 @@
+"""Lambda handler for aggregated run statistics."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from data.runs import list_all_runs
+from handlers.utils.validation import get_user_id
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+CORS_HEADERS = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    "Access-Control-Allow-Methods": "GET,OPTIONS",
+}
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Handle GET /stats requests."""
+    http_method = event.get("httpMethod", "")
+
+    if http_method == "OPTIONS":
+        return {"statusCode": 200, "headers": CORS_HEADERS, "body": ""}
+
+    if http_method != "GET":
+        return _error(405, "Method not allowed")
+
+    user_id = get_user_id(event)
+    if not user_id:
+        return _error(401, "Unauthorized")
+
+    runs = list_all_runs(user_id)
+    now = datetime.now(timezone.utc)
+    stats = compute_stats(runs, now)
+    return _success(stats)
+
+
+def compute_stats(runs: list[dict[str, Any]], now: datetime) -> dict[str, Any]:
+    """Compute aggregated statistics from a list of runs."""
+    completed = [r for r in runs if r.get("status") == "completed"]
+
+    current_week_start = _week_start(now)
+    current_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    prev_week_start = current_week_start - timedelta(weeks=1)
+    prev_month_start = _prev_month_start(current_month_start)
+
+    current_week_end = current_week_start + timedelta(weeks=1)
+    current_month_end = _next_month_start(current_month_start)
+    prev_week_end = current_week_start
+    prev_month_end = current_month_start
+
+    return {
+        "currentWeek": _period_summary(completed, current_week_start, current_week_end),
+        "currentMonth": _period_summary(completed, current_month_start, current_month_end),
+        "previousWeek": _period_summary(completed, prev_week_start, prev_week_end),
+        "previousMonth": _period_summary(completed, prev_month_start, prev_month_end),
+        "weeklyDistances": _weekly_distances(completed, now, weeks=8),
+        "monthlyDistances": _monthly_distances(completed, now, months=6),
+        "personalRecords": _personal_records(completed),
+        "allTime": _all_time(completed),
+    }
+
+
+def _parse_run_date(run: dict[str, Any]) -> datetime | None:
+    """Parse runDate from a run dict. Returns None on failure."""
+    raw = run.get("runDate")
+    if not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _week_start(dt: datetime) -> datetime:
+    """Return Monday 00:00 UTC for the week containing dt."""
+    monday = dt - timedelta(days=dt.weekday())
+    return monday.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _prev_month_start(month_start: datetime) -> datetime:
+    """Return first day of the previous month."""
+    prev = month_start - timedelta(days=1)
+    return prev.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _next_month_start(month_start: datetime) -> datetime:
+    """Return first day of the next month."""
+    if month_start.month == 12:
+        return month_start.replace(year=month_start.year + 1, month=1)
+    return month_start.replace(month=month_start.month + 1)
+
+
+def _runs_in_period(
+    runs: list[dict[str, Any]], start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    """Filter runs whose runDate falls within [start, end)."""
+    result = []
+    for run in runs:
+        dt = _parse_run_date(run)
+        if dt is not None and start <= dt < end:
+            result.append(run)
+    return result
+
+
+def _period_summary(
+    runs: list[dict[str, Any]], start: datetime, end: datetime
+) -> dict[str, Any]:
+    """Compute summary metrics for runs in a given time period."""
+    period_runs = _runs_in_period(runs, start, end)
+    total_distance = sum(r.get("distanceMeters", 0) for r in period_runs)
+    total_duration = sum(r.get("durationSeconds", 0) for r in period_runs)
+    run_count = len(period_runs)
+
+    avg_pace = 0.0
+    if total_distance > 0 and total_duration > 0:
+        avg_pace = round(total_duration / (total_distance / 1000), 1)
+
+    return {
+        "totalDistanceMeters": total_distance,
+        "totalDurationSeconds": total_duration,
+        "runCount": run_count,
+        "avgPaceSecondsPerKm": avg_pace,
+    }
+
+
+def _weekly_distances(
+    runs: list[dict[str, Any]], now: datetime, weeks: int = 8
+) -> list[dict[str, str | float]]:
+    """Return distance totals for the last N weeks."""
+    result = []
+    current_ws = _week_start(now)
+    for i in range(weeks):
+        ws = current_ws - timedelta(weeks=i)
+        we = ws + timedelta(weeks=1)
+        period_runs = _runs_in_period(runs, ws, we)
+        total = sum(r.get("distanceMeters", 0) for r in period_runs)
+        result.append({
+            "weekStart": ws.strftime("%Y-%m-%d"),
+            "distanceMeters": total,
+        })
+    result.reverse()
+    return result
+
+
+def _monthly_distances(
+    runs: list[dict[str, Any]], now: datetime, months: int = 6
+) -> list[dict[str, str | float]]:
+    """Return distance totals for the last N months."""
+    result = []
+    ms = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    for i in range(months):
+        me = _next_month_start(ms)
+        period_runs = _runs_in_period(runs, ms, me)
+        total = sum(r.get("distanceMeters", 0) for r in period_runs)
+        result.append({
+            "month": ms.strftime("%Y-%m"),
+            "distanceMeters": total,
+        })
+        ms = _prev_month_start(ms)
+    result.reverse()
+    return result
+
+
+def _personal_records(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute personal records from all completed runs."""
+    longest_run = 0.0
+    fastest_pace = 0.0
+    most_distance_in_week: float = 0.0
+    most_runs_in_week = 0
+
+    # Per-run records
+    for run in runs:
+        dist = run.get("distanceMeters", 0)
+        if dist > longest_run:
+            longest_run = dist
+
+        pace = run.get("paceSecondsPerKm")
+        if pace and pace > 0:
+            if fastest_pace == 0 or pace < fastest_pace:
+                fastest_pace = pace
+
+    # Weekly aggregates
+    week_distances: dict[str, float] = {}
+    week_counts: dict[str, int] = {}
+    for run in runs:
+        dt = _parse_run_date(run)
+        if dt is None:
+            continue
+        ws = _week_start(dt).strftime("%Y-%m-%d")
+        week_distances[ws] = week_distances.get(ws, 0) + run.get("distanceMeters", 0)
+        week_counts[ws] = week_counts.get(ws, 0) + 1
+
+    if week_distances:
+        most_distance_in_week = max(week_distances.values())
+    if week_counts:
+        most_runs_in_week = max(week_counts.values())
+
+    return {
+        "longestRunMeters": longest_run,
+        "fastestPaceSecondsPerKm": fastest_pace,
+        "mostDistanceInWeekMeters": most_distance_in_week,
+        "mostRunsInWeek": most_runs_in_week,
+    }
+
+
+def _all_time(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute all-time totals."""
+    total_distance = sum(r.get("distanceMeters", 0) for r in runs)
+    total_duration = sum(r.get("durationSeconds", 0) for r in runs)
+    return {
+        "totalDistanceMeters": total_distance,
+        "totalRuns": len(runs),
+        "totalDurationSeconds": total_duration,
+    }
+
+
+def _success(data: Any) -> dict[str, Any]:
+    return {
+        "statusCode": 200,
+        "headers": CORS_HEADERS,
+        "body": json.dumps(data),
+    }
+
+
+def _error(status_code: int, message: str) -> dict[str, Any]:
+    return {
+        "statusCode": status_code,
+        "headers": CORS_HEADERS,
+        "body": json.dumps({"error": message}),
+    }

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,0 +1,385 @@
+"""Tests for stats Lambda handler."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from handlers.stats import compute_stats, handler
+
+
+def _make_event(
+    method: str = "GET",
+    user_id: str = "test-user-123",
+) -> dict:
+    return {
+        "httpMethod": method,
+        "resource": "/stats",
+        "requestContext": {
+            "authorizer": {
+                "claims": {"sub": user_id},
+            },
+        },
+        "body": None,
+        "pathParameters": None,
+    }
+
+
+def _make_run(
+    run_date: str,
+    distance: float = 5000,
+    duration: float = 1800,
+    pace: float | None = 360.0,
+    status: str = "completed",
+) -> dict:
+    run: dict = {
+        "runId": "ABC",
+        "status": status,
+        "runDate": run_date,
+        "distanceMeters": distance,
+        "durationSeconds": duration,
+    }
+    if pace is not None:
+        run["paceSecondsPerKm"] = pace
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Handler-level tests
+# ---------------------------------------------------------------------------
+
+
+@patch("handlers.stats.list_all_runs")
+def test_get_stats_success(mock_list: object) -> None:
+    mock_list.return_value = []
+    response = handler(_make_event(), None)
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert "currentWeek" in body
+    assert "allTime" in body
+
+
+@patch("handlers.stats.list_all_runs")
+def test_get_stats_with_runs(mock_list: object) -> None:
+    now = datetime.now(timezone.utc)
+    mock_list.return_value = [
+        _make_run(now.isoformat(), distance=5000, duration=1800),
+    ]
+    response = handler(_make_event(), None)
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["allTime"]["totalRuns"] == 1
+    assert body["allTime"]["totalDistanceMeters"] == 5000
+
+
+def test_stats_unauthorized() -> None:
+    event = {
+        "httpMethod": "GET",
+        "resource": "/stats",
+        "requestContext": {},
+        "body": None,
+        "pathParameters": None,
+    }
+    response = handler(event, None)
+    assert response["statusCode"] == 401
+
+
+def test_stats_method_not_allowed() -> None:
+    response = handler(_make_event(method="POST"), None)
+    assert response["statusCode"] == 405
+
+
+def test_stats_options() -> None:
+    response = handler(_make_event(method="OPTIONS"), None)
+    assert response["statusCode"] == 200
+
+
+# ---------------------------------------------------------------------------
+# compute_stats — zero runs
+# ---------------------------------------------------------------------------
+
+
+def test_zero_runs() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    stats = compute_stats([], now)
+
+    assert stats["currentWeek"]["runCount"] == 0
+    assert stats["currentWeek"]["totalDistanceMeters"] == 0
+    assert stats["currentWeek"]["totalDurationSeconds"] == 0
+    assert stats["currentWeek"]["avgPaceSecondsPerKm"] == 0.0
+    assert stats["currentMonth"]["runCount"] == 0
+    assert stats["previousWeek"]["runCount"] == 0
+    assert stats["previousMonth"]["runCount"] == 0
+    assert stats["allTime"]["totalRuns"] == 0
+    assert stats["allTime"]["totalDistanceMeters"] == 0
+    assert stats["allTime"]["totalDurationSeconds"] == 0
+    assert stats["personalRecords"]["longestRunMeters"] == 0
+    assert stats["personalRecords"]["fastestPaceSecondsPerKm"] == 0
+    assert stats["personalRecords"]["mostDistanceInWeekMeters"] == 0
+    assert stats["personalRecords"]["mostRunsInWeek"] == 0
+    assert len(stats["weeklyDistances"]) == 8
+    assert len(stats["monthlyDistances"]) == 6
+    assert all(w["distanceMeters"] == 0 for w in stats["weeklyDistances"])
+    assert all(m["distanceMeters"] == 0 for m in stats["monthlyDistances"])
+
+
+# ---------------------------------------------------------------------------
+# compute_stats — single run
+# ---------------------------------------------------------------------------
+
+
+def test_single_run_current_week() -> None:
+    # Tuesday March 24 2026 — week starts Monday March 23
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [_make_run("2026-03-24T08:00:00Z", distance=10000, duration=3600, pace=360.0)]
+    stats = compute_stats(runs, now)
+
+    assert stats["currentWeek"]["runCount"] == 1
+    assert stats["currentWeek"]["totalDistanceMeters"] == 10000
+    assert stats["currentWeek"]["totalDurationSeconds"] == 3600
+    assert stats["currentWeek"]["avgPaceSecondsPerKm"] == 360.0
+
+    assert stats["allTime"]["totalRuns"] == 1
+    assert stats["allTime"]["totalDistanceMeters"] == 10000
+
+    assert stats["personalRecords"]["longestRunMeters"] == 10000
+    assert stats["personalRecords"]["fastestPaceSecondsPerKm"] == 360.0
+    assert stats["personalRecords"]["mostRunsInWeek"] == 1
+
+
+# ---------------------------------------------------------------------------
+# compute_stats — multiple runs across weeks/months
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_runs_across_periods() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [
+        # Current week (March 23-29)
+        _make_run("2026-03-24T08:00:00Z", distance=5000, duration=1800, pace=360.0),
+        _make_run("2026-03-25T08:00:00Z", distance=3000, duration=1200, pace=400.0),
+        # Previous week (March 16-22)
+        _make_run("2026-03-17T08:00:00Z", distance=8000, duration=2800, pace=350.0),
+        # Previous month (February)
+        _make_run("2026-02-15T08:00:00Z", distance=12000, duration=4200, pace=350.0),
+        # Older (January)
+        _make_run("2026-01-10T08:00:00Z", distance=6000, duration=2400, pace=400.0),
+    ]
+    stats = compute_stats(runs, now)
+
+    # Current week: 2 runs, 8000m, 3000s
+    assert stats["currentWeek"]["runCount"] == 2
+    assert stats["currentWeek"]["totalDistanceMeters"] == 8000
+    assert stats["currentWeek"]["totalDurationSeconds"] == 3000
+
+    # Previous week: 1 run
+    assert stats["previousWeek"]["runCount"] == 1
+    assert stats["previousWeek"]["totalDistanceMeters"] == 8000
+
+    # Current month (March): 3 runs
+    assert stats["currentMonth"]["runCount"] == 3
+
+    # Previous month (February): 1 run
+    assert stats["previousMonth"]["runCount"] == 1
+    assert stats["previousMonth"]["totalDistanceMeters"] == 12000
+
+    # All-time
+    assert stats["allTime"]["totalRuns"] == 5
+    assert stats["allTime"]["totalDistanceMeters"] == 34000
+
+
+# ---------------------------------------------------------------------------
+# Personal records
+# ---------------------------------------------------------------------------
+
+
+def test_personal_records() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [
+        _make_run("2026-03-24T08:00:00Z", distance=5000, duration=1800, pace=360.0),
+        _make_run("2026-03-24T09:00:00Z", distance=15000, duration=5400, pace=360.0),
+        _make_run("2026-03-17T08:00:00Z", distance=3000, duration=900, pace=300.0),
+    ]
+    stats = compute_stats(runs, now)
+
+    pr = stats["personalRecords"]
+    assert pr["longestRunMeters"] == 15000
+    assert pr["fastestPaceSecondsPerKm"] == 300.0
+    # Week of March 23: 20000m (two runs)
+    assert pr["mostDistanceInWeekMeters"] == 20000
+    # Week of March 23 has 2 runs
+    assert pr["mostRunsInWeek"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Weekly and monthly distances
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_distances_ordering() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [
+        _make_run("2026-03-24T08:00:00Z", distance=5000, duration=1800),
+        _make_run("2026-03-10T08:00:00Z", distance=3000, duration=1200),
+    ]
+    stats = compute_stats(runs, now)
+
+    weekly = stats["weeklyDistances"]
+    assert len(weekly) == 8
+    # Should be oldest first
+    assert weekly[0]["weekStart"] < weekly[-1]["weekStart"]
+    # Last entry (current week) should have 5000
+    assert weekly[-1]["distanceMeters"] == 5000
+
+
+def test_monthly_distances_ordering() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [
+        _make_run("2026-03-24T08:00:00Z", distance=5000, duration=1800),
+        _make_run("2026-01-15T08:00:00Z", distance=7000, duration=2800),
+    ]
+    stats = compute_stats(runs, now)
+
+    monthly = stats["monthlyDistances"]
+    assert len(monthly) == 6
+    # Should be oldest first
+    assert monthly[0]["month"] < monthly[-1]["month"]
+    # Last entry (March 2026) should have 5000
+    assert monthly[-1]["distanceMeters"] == 5000
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_planned_runs_excluded_from_stats() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [
+        _make_run("2026-03-24T08:00:00Z", distance=5000, duration=1800, status="planned"),
+        _make_run("2026-03-24T09:00:00Z", distance=3000, duration=1200, status="completed"),
+    ]
+    stats = compute_stats(runs, now)
+
+    assert stats["allTime"]["totalRuns"] == 1
+    assert stats["allTime"]["totalDistanceMeters"] == 3000
+    assert stats["currentWeek"]["runCount"] == 1
+
+
+def test_run_with_missing_distance() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    run = {
+        "runId": "ABC",
+        "status": "completed",
+        "runDate": "2026-03-24T08:00:00Z",
+        "durationSeconds": 1800,
+    }
+    stats = compute_stats([run], now)
+
+    assert stats["allTime"]["totalRuns"] == 1
+    assert stats["allTime"]["totalDistanceMeters"] == 0
+    assert stats["currentWeek"]["avgPaceSecondsPerKm"] == 0.0
+
+
+def test_run_with_invalid_date_skipped() -> None:
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    run = {
+        "runId": "ABC",
+        "status": "completed",
+        "runDate": "not-a-date",
+        "distanceMeters": 5000,
+        "durationSeconds": 1800,
+    }
+    stats = compute_stats([run], now)
+
+    # Run counts in allTime but not in any period
+    assert stats["allTime"]["totalRuns"] == 1
+    assert stats["currentWeek"]["runCount"] == 0
+    assert stats["personalRecords"]["longestRunMeters"] == 5000
+
+
+def test_week_boundary_monday() -> None:
+    """Run on Sunday should be in the previous week, not current."""
+    # March 24, 2026 is Tuesday. Week starts Monday March 23.
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    # March 22 is Sunday — belongs to previous week (March 16-22)
+    runs = [_make_run("2026-03-22T23:59:00Z", distance=5000, duration=1800)]
+    stats = compute_stats(runs, now)
+
+    assert stats["currentWeek"]["runCount"] == 0
+    assert stats["previousWeek"]["runCount"] == 1
+
+
+def test_month_boundary() -> None:
+    """Run on last day of previous month should be in previous month."""
+    now = datetime(2026, 3, 1, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [_make_run("2026-02-28T23:59:00Z", distance=5000, duration=1800)]
+    stats = compute_stats(runs, now)
+
+    assert stats["currentMonth"]["runCount"] == 0
+    assert stats["previousMonth"]["runCount"] == 1
+
+
+def test_avg_pace_with_zero_distance() -> None:
+    """Avg pace should be 0 when total distance is 0."""
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    run = {
+        "runId": "ABC",
+        "status": "completed",
+        "runDate": "2026-03-24T08:00:00Z",
+        "distanceMeters": 0,
+        "durationSeconds": 1800,
+    }
+    stats = compute_stats([run], now)
+    assert stats["currentWeek"]["avgPaceSecondsPerKm"] == 0.0
+
+
+def test_run_without_pace_in_personal_records() -> None:
+    """Runs without paceSecondsPerKm shouldn't affect fastest pace."""
+    now = datetime(2026, 3, 24, 12, 0, 0, tzinfo=timezone.utc)
+    runs = [
+        _make_run("2026-03-24T08:00:00Z", distance=5000, duration=1800, pace=None),
+        _make_run("2026-03-24T09:00:00Z", distance=3000, duration=1200, pace=400.0),
+    ]
+    stats = compute_stats(runs, now)
+    assert stats["personalRecords"]["fastestPaceSecondsPerKm"] == 400.0
+
+
+# ---------------------------------------------------------------------------
+# Data layer test for list_all_runs pagination
+# ---------------------------------------------------------------------------
+
+
+@patch("data.runs.get_table")
+def test_list_all_runs_pagination(mock_get_table: object) -> None:
+    from data.runs import list_all_runs
+
+    mock_table = type("MockTable", (), {})()
+
+    call_count = 0
+
+    def mock_query(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {
+                "Items": [
+                    {"userId": "u1", "sk": "RUN#A", "distanceMeters": 5000},
+                ],
+                "LastEvaluatedKey": {"userId": "u1", "sk": "RUN#A"},
+            }
+        return {
+            "Items": [
+                {"userId": "u1", "sk": "RUN#B", "distanceMeters": 3000},
+            ],
+        }
+
+    mock_table.query = mock_query
+    mock_get_table.return_value = mock_table
+
+    result = list_all_runs("u1")
+    assert len(result) == 2
+    assert result[0]["runId"] == "A"
+    assert result[1]["runId"] == "B"
+    assert call_count == 2

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,7 @@
 import { fetchAuthSession } from "@aws-amplify/auth";
 import type { Run, CreateRunPayload, UpdateRunPayload, CompleteRunPayload } from "../types/run";
 import type { Profile } from "../types/profile";
+import type { Stats } from "../types/stats";
 
 const BASE_URL = import.meta.env.VITE_API_URL as string;
 
@@ -87,4 +88,8 @@ export function completeRun(id: string, data: CompleteRunPayload): Promise<Run> 
     method: "POST",
     body: JSON.stringify(data),
   });
+}
+
+export function getStats(): Promise<Stats> {
+  return request<Stats>("/stats");
 }

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,0 +1,40 @@
+export interface PeriodSummary {
+  totalDistanceMeters: number;
+  totalDurationSeconds: number;
+  runCount: number;
+  avgPaceSecondsPerKm: number;
+}
+
+export interface WeeklyDistance {
+  weekStart: string;
+  distanceMeters: number;
+}
+
+export interface MonthlyDistance {
+  month: string;
+  distanceMeters: number;
+}
+
+export interface PersonalRecords {
+  longestRunMeters: number;
+  fastestPaceSecondsPerKm: number;
+  mostDistanceInWeekMeters: number;
+  mostRunsInWeek: number;
+}
+
+export interface AllTime {
+  totalDistanceMeters: number;
+  totalRuns: number;
+  totalDurationSeconds: number;
+}
+
+export interface Stats {
+  currentWeek: PeriodSummary;
+  currentMonth: PeriodSummary;
+  previousWeek: PeriodSummary;
+  previousMonth: PeriodSummary;
+  weeklyDistances: WeeklyDistance[];
+  monthlyDistances: MonthlyDistance[];
+  personalRecords: PersonalRecords;
+  allTime: AllTime;
+}

--- a/infra/stacks/api_stack.py
+++ b/infra/stacks/api_stack.py
@@ -55,9 +55,22 @@ class ApiStack(Stack):
             timeout=Duration.seconds(10),
         )
 
+        # Stats handler
+        stats_fn = _lambda.Function(
+            self,
+            "StatsHandler",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            architecture=_lambda.Architecture.ARM_64,
+            handler="handlers.stats.handler",
+            code=_lambda.Code.from_asset("../backend"),
+            environment=lambda_env,
+            timeout=Duration.seconds(10),
+        )
+
         # Grant DynamoDB access
         table.grant_read_write_data(profile_fn)
         table.grant_read_write_data(runs_fn)
+        table.grant_read_data(stats_fn)
 
         # Cognito authorizer
         authorizer = apigw.CognitoUserPoolsAuthorizer(
@@ -102,5 +115,10 @@ class ApiStack(Stack):
 
         complete_resource = run_resource.add_resource("complete")
         complete_resource.add_method("POST", runs_integration, **auth_method_options)
+
+        # Stats routes
+        stats_resource = api.root.add_resource("stats")
+        stats_integration = apigw.LambdaIntegration(stats_fn)
+        stats_resource.add_method("GET", stats_integration, **auth_method_options)
 
         CfnOutput(self, "ApiUrl", value=api.url)


### PR DESCRIPTION
## Summary
- Adds `GET /stats` endpoint returning aggregated run statistics: weekly/monthly summaries, personal records, distance chart data, all-time totals
- New `list_all_runs` data layer function with full DynamoDB pagination
- CDK infra: new Stats Lambda with read-only DynamoDB access and Cognito-authorized API Gateway route
- Frontend: `getStats()` API client function and `Stats` TypeScript types

Closes #26

## Test plan
- [x] 19 new backend tests covering: zero runs, single run, multiple runs across weeks/months, personal records, week/month boundaries, edge cases, pagination
- [x] All 69 backend tests pass
- [x] All 53 frontend tests pass
- [x] CDK synth succeeds
- [x] Frontend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)