### PR TITLE
feat: profile page read-only mode with edit toggle (#21)

### DIFF
--- a/frontend/e2e/profile.spec.ts
+++ b/frontend/e2e/profile.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "./fixtures/auth";
+
+const MOCK_PROFILE = {
+  email: "test@example.com",
+  displayName: "Test User",
+  weightKg: 75,
+  heightCm: 180,
+};
+
+function mockProfileApi(page: import("@playwright/test").Page) {
+  return page.route("**/profile", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_PROFILE),
+      });
+    }
+    if (route.request().method() === "PUT") {
+      const body = route.request().postDataJSON();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+    }
+    return route.continue();
+  });
+}
+
+test.describe("Profile page", () => {
+  test("defaults to view mode with profile data displayed as text", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockProfileApi(page);
+    await page.goto("/profile");
+
+    await expect(page.getByTestId("view-email")).toHaveText("test@example.com");
+    await expect(page.getByTestId("view-displayName")).toHaveText("Test User");
+    await expect(page.getByTestId("view-heightCm")).toHaveText("180");
+    await expect(page.getByTestId("view-weightKg")).toHaveText("75");
+
+    await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign Out" })).toBeVisible();
+  });
+
+  test("view → edit → save persists changes and returns to view mode", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockProfileApi(page);
+    await page.goto("/profile");
+
+    await expect(page.getByTestId("view-displayName")).toHaveText("Test User");
+
+    // Enter edit mode
+    await page.getByRole("button", { name: "Edit" }).click();
+    await expect(page.locator("#displayName")).toBeVisible();
+
+    // Change display name
+    await page.locator("#displayName").clear();
+    await page.locator("#displayName").fill("Updated Name");
+
+    // Save
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Should be back in view mode with updated value
+    await expect(page.getByTestId("view-displayName")).toHaveText("Updated Name");
+    await expect(page.getByText("Profile saved!")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
+  });
+
+  test("view → edit → cancel discards changes and returns to view mode", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockProfileApi(page);
+    await page.goto("/profile");
+
+    await expect(page.getByTestId("view-displayName")).toHaveText("Test User");
+
+    // Enter edit mode
+    await page.getByRole("button", { name: "Edit" }).click();
+    await expect(page.locator("#displayName")).toBeVisible();
+
+    // Change display name
+    await page.locator("#displayName").clear();
+    await page.locator("#displayName").fill("Should Be Discarded");
+
+    // Cancel
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    // Should be back in view mode with original value
+    await expect(page.getByTestId("view-displayName")).toHaveText("Test User");
+    await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
+  });
+
+  test("Sign Out button is visible in both view and edit modes", async ({
+    authenticatedPage: page,
+  }) => {
+    await mockProfileApi(page);
+    await page.goto("/profile");
+
+    // View mode
+    await expect(page.getByRole("button", { name: "Sign Out" })).toBeVisible();
+
+    // Edit mode
+    await page.getByRole("button", { name: "Edit" }).click();
+    await expect(page.getByRole("button", { name: "Sign Out" })).toBeVisible();
+  });
+});

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -3,10 +3,12 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ProfilePage } from "../pages/ProfilePage";
 
+const mockSignOut = vi.fn();
+
 vi.mock("../auth/AuthProvider", () => ({
   useAuth: () => ({
     user: { email: "test@example.com", userId: "user-123" },
-    signOut: vi.fn(),
+    signOut: mockSignOut,
   }),
 }));
 
@@ -30,6 +32,12 @@ function renderPage() {
   );
 }
 
+async function waitForLoaded() {
+  await waitFor(() => {
+    expect(screen.queryByText("Loading profile...")).not.toBeInTheDocument();
+  });
+}
+
 describe("ProfilePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,72 +49,176 @@ describe("ProfilePage", () => {
     expect(screen.getByText("Loading profile...")).toBeInTheDocument();
   });
 
-  it("renders form fields after loading", async () => {
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByLabelText("Email *")).toBeInTheDocument();
+  describe("view mode (default)", () => {
+    it("displays profile fields as text after loading", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      expect(screen.getByTestId("view-email")).toHaveTextContent("test@example.com");
+      expect(screen.getByTestId("view-displayName")).toHaveTextContent("Test User");
+      expect(screen.getByTestId("view-heightCm")).toHaveTextContent("180");
+      expect(screen.getByTestId("view-weightKg")).toHaveTextContent("75");
     });
-    expect(screen.getByLabelText("Display Name *")).toBeInTheDocument();
-    expect(screen.getByLabelText("Weight (kg) *")).toBeInTheDocument();
-    expect(screen.getByLabelText("Height (cm) *")).toBeInTheDocument();
+
+    it("does not render form inputs in view mode", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      expect(screen.queryByLabelText("Email *")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Display Name *")).not.toBeInTheDocument();
+    });
+
+    it("renders Edit button", async () => {
+      renderPage();
+      await waitForLoaded();
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+
+    it("does not render Save or Cancel buttons", async () => {
+      renderPage();
+      await waitForLoaded();
+      expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+    });
+
+    it("renders Sign Out button", async () => {
+      renderPage();
+      await waitForLoaded();
+      expect(screen.getByRole("button", { name: "Sign Out" })).toBeInTheDocument();
+    });
   });
 
-  it("does not render birth date field", async () => {
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByLabelText("Email *")).toBeInTheDocument();
-    });
-    expect(screen.queryByLabelText("Birth Date")).not.toBeInTheDocument();
-  });
+  describe("edit mode", () => {
+    async function enterEditMode() {
+      renderPage();
+      await waitForLoaded();
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    }
 
-  it("populates form with loaded profile data", async () => {
-    renderPage();
-    await waitFor(() => {
+    it("switches to edit mode when Edit is clicked", async () => {
+      await enterEditMode();
+
+      expect(screen.getByLabelText("Email *")).toBeInTheDocument();
+      expect(screen.getByLabelText("Display Name *")).toBeInTheDocument();
+      expect(screen.getByLabelText("Height (cm) *")).toBeInTheDocument();
+      expect(screen.getByLabelText("Weight (kg) *")).toBeInTheDocument();
+    });
+
+    it("populates inputs with current values", async () => {
+      await enterEditMode();
+
       expect(screen.getByLabelText("Email *")).toHaveValue("test@example.com");
+      expect(screen.getByLabelText("Display Name *")).toHaveValue("Test User");
+      expect(screen.getByLabelText("Height (cm) *")).toHaveValue(180);
+      expect(screen.getByLabelText("Weight (kg) *")).toHaveValue(75);
     });
-    expect(screen.getByLabelText("Display Name *")).toHaveValue("Test User");
-    expect(screen.getByLabelText("Weight (kg) *")).toHaveValue(75);
-    expect(screen.getByLabelText("Height (cm) *")).toHaveValue(180);
-  });
 
-  it("renders save button", async () => {
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText("Save Profile")).toBeInTheDocument();
+    it("shows Save and Cancel buttons", async () => {
+      await enterEditMode();
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     });
-  });
 
-  it("renders sign out button", async () => {
-    renderPage();
-    await waitFor(() => {
-      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    it("does not show Edit button in edit mode", async () => {
+      await enterEditMode();
+      expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
     });
-  });
 
-  it("marks all fields as required", async () => {
-    renderPage();
-    await waitFor(() => {
+    it("shows Sign Out button in edit mode", async () => {
+      await enterEditMode();
+      expect(screen.getByRole("button", { name: "Sign Out" })).toBeInTheDocument();
+    });
+
+    it("marks all fields as required", async () => {
+      await enterEditMode();
+
       expect(screen.getByLabelText("Email *")).toBeRequired();
+      expect(screen.getByLabelText("Display Name *")).toBeRequired();
+      expect(screen.getByLabelText("Height (cm) *")).toBeRequired();
+      expect(screen.getByLabelText("Weight (kg) *")).toBeRequired();
     });
-    expect(screen.getByLabelText("Display Name *")).toBeRequired();
-    expect(screen.getByLabelText("Height (cm) *")).toBeRequired();
-    expect(screen.getByLabelText("Weight (kg) *")).toBeRequired();
   });
 
-  it("shows validation error for invalid email on save", async () => {
-    renderPage();
-    await waitFor(() => {
+  describe("cancel", () => {
+    it("returns to view mode and discards changes", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+      fireEvent.change(screen.getByLabelText("Display Name *"), {
+        target: { value: "Changed Name" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      // Back in view mode with original values
+      expect(screen.getByTestId("view-displayName")).toHaveTextContent("Test User");
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+  });
+
+  describe("save", () => {
+    it("saves profile and returns to view mode with updated values", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+      fireEvent.change(screen.getByLabelText("Display Name *"), {
+        target: { value: "New Name" },
+      });
+
+      const form = screen.getByRole("button", { name: "Save" }).closest("form") as HTMLFormElement;
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("view-displayName")).toHaveTextContent("New Name");
+      });
+
+      expect(mockUpdateProfile).toHaveBeenCalledWith({
+        email: "test@example.com",
+        displayName: "New Name",
+        heightCm: 180,
+        weightKg: 75,
+      });
+      expect(screen.getByText("Profile saved!")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+
+    it("shows validation error for invalid email on save", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+      fireEvent.change(screen.getByLabelText("Email *"), {
+        target: { value: "not-an-email" },
+      });
+
+      const form = screen.getByRole("button", { name: "Save" }).closest("form") as HTMLFormElement;
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(screen.getByText("Please enter a valid email address")).toBeInTheDocument();
+      });
+      // Should stay in edit mode on error
       expect(screen.getByLabelText("Email *")).toBeInTheDocument();
     });
 
-    const emailInput = screen.getByLabelText("Email *");
-    fireEvent.change(emailInput, { target: { value: "not-an-email" } });
+    it("stays in edit mode on save failure", async () => {
+      mockUpdateProfile.mockRejectedValueOnce(new Error("Network error"));
 
-    const form = screen.getByText("Save Profile").closest("form") as HTMLFormElement;
-    fireEvent.submit(form);
+      renderPage();
+      await waitForLoaded();
 
-    await waitFor(() => {
-      expect(screen.getByText("Please enter a valid email address")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+      const form = screen.getByRole("button", { name: "Save" }).closest("form") as HTMLFormElement;
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
+      // Still in edit mode
+      expect(screen.getByLabelText("Email *")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -17,17 +17,32 @@ export function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [mode, setMode] = useState<"view" | "edit">("view");
+
+  // Saved values to restore on cancel
+  const [savedValues, setSavedValues] = useState({
+    email: "",
+    displayName: "",
+    weightKg: "",
+    heightCm: "",
+  });
 
   useEffect(() => {
     getProfile()
       .then((profile) => {
-        setEmail(profile.email ?? "");
-        setDisplayName(profile.displayName ?? "");
-        setWeightKg(profile.weightKg?.toString() ?? "");
-        setHeightCm(profile.heightCm?.toString() ?? "");
+        const values = {
+          email: profile.email ?? "",
+          displayName: profile.displayName ?? "",
+          weightKg: profile.weightKg?.toString() ?? "",
+          heightCm: profile.heightCm?.toString() ?? "",
+        };
+        setEmail(values.email);
+        setDisplayName(values.displayName);
+        setWeightKg(values.weightKg);
+        setHeightCm(values.heightCm);
+        setSavedValues(values);
       })
       .catch((err: unknown) => {
-        // 404 = no profile yet, just show empty form
         if (err instanceof Error && err.message.includes("404")) return;
         const message = err instanceof Error ? err.message : "Failed to load profile";
         setError(message);
@@ -68,13 +83,37 @@ export function ProfilePage() {
 
     try {
       await updateProfile(data);
+      const newSaved = {
+        email: data.email,
+        displayName: data.displayName,
+        weightKg: data.weightKg.toString(),
+        heightCm: data.heightCm.toString(),
+      };
+      setSavedValues(newSaved);
       setSuccess(true);
+      setMode("view");
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to save profile";
       setError(message);
     } finally {
       setSaving(false);
     }
+  }
+
+  function handleEdit() {
+    setError(null);
+    setSuccess(false);
+    setMode("edit");
+  }
+
+  function handleCancel() {
+    setEmail(savedValues.email);
+    setDisplayName(savedValues.displayName);
+    setWeightKg(savedValues.weightKg);
+    setHeightCm(savedValues.heightCm);
+    setError(null);
+    setSuccess(false);
+    setMode("view");
   }
 
   if (loading) {
@@ -91,79 +130,135 @@ export function ProfilePage() {
         <h1 className={shared.pageTitle}>Profile</h1>
       </div>
 
-      <form className={shared.card} onSubmit={handleSave}>
-        {error && <div className={shared.errorState}>{error}</div>}
-        {success && <div className={styles.success}>Profile saved!</div>}
+      {mode === "view" ? (
+        <div className={shared.card}>
+          {error && <div className={shared.errorState}>{error}</div>}
+          {success && <div className={styles.success}>Profile saved!</div>}
 
-        <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="email">Email *</label>
-          <input
-            id="email"
-            className={shared.formInput}
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </div>
+          <div className={styles.fieldGroup}>
+            <span className={styles.fieldLabel}>Email</span>
+            <span className={styles.fieldValue} data-testid="view-email">{email || "—"}</span>
+          </div>
 
-        <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="displayName">Display Name *</label>
-          <input
-            id="displayName"
-            className={shared.formInput}
-            type="text"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            required
-          />
-        </div>
+          <div className={styles.fieldGroup}>
+            <span className={styles.fieldLabel}>Display Name</span>
+            <span className={styles.fieldValue} data-testid="view-displayName">{displayName || "—"}</span>
+          </div>
 
-        <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="heightCm">Height (cm) *</label>
-          <input
-            id="heightCm"
-            className={shared.formInput}
-            type="number"
-            value={heightCm}
-            onChange={(e) => setHeightCm(e.target.value)}
-            required
-          />
-        </div>
+          <div className={styles.fieldGroup}>
+            <span className={styles.fieldLabel}>Height (cm)</span>
+            <span className={styles.fieldValue} data-testid="view-heightCm">{heightCm || "—"}</span>
+          </div>
 
-        <div className={shared.formGroup}>
-          <label className={shared.formLabel} htmlFor="weightKg">Weight (kg) *</label>
-          <input
-            id="weightKg"
-            className={shared.formInput}
-            type="number"
-            step="0.1"
-            value={weightKg}
-            onChange={(e) => setWeightKg(e.target.value)}
-            required
-          />
-        </div>
+          <div className={styles.fieldGroup}>
+            <span className={styles.fieldLabel}>Weight (kg)</span>
+            <span className={styles.fieldValue} data-testid="view-weightKg">{weightKg || "—"}</span>
+          </div>
 
-        <button
-          type="submit"
-          className={shared.buttonPrimary}
-          disabled={saving}
-          style={{ width: "100%" }}
-        >
-          {saving ? "Saving..." : "Save Profile"}
-        </button>
-
-        <div className={styles.signOutSection}>
           <button
             type="button"
-            className={shared.buttonSecondary}
-            onClick={signOut}
+            className={shared.buttonPrimary}
+            onClick={handleEdit}
             style={{ width: "100%" }}
           >
-            Sign Out
+            Edit
           </button>
+
+          <div className={styles.signOutSection}>
+            <button
+              type="button"
+              className={shared.buttonSecondary}
+              onClick={signOut}
+              style={{ width: "100%" }}
+            >
+              Sign Out
+            </button>
+          </div>
         </div>
-      </form>
+      ) : (
+        <form className={shared.card} onSubmit={handleSave}>
+          {error && <div className={shared.errorState}>{error}</div>}
+
+          <div className={shared.formGroup}>
+            <label className={shared.formLabel} htmlFor="email">Email *</label>
+            <input
+              id="email"
+              className={shared.formInput}
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className={shared.formGroup}>
+            <label className={shared.formLabel} htmlFor="displayName">Display Name *</label>
+            <input
+              id="displayName"
+              className={shared.formInput}
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className={shared.formGroup}>
+            <label className={shared.formLabel} htmlFor="heightCm">Height (cm) *</label>
+            <input
+              id="heightCm"
+              className={shared.formInput}
+              type="number"
+              value={heightCm}
+              onChange={(e) => setHeightCm(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className={shared.formGroup}>
+            <label className={shared.formLabel} htmlFor="weightKg">Weight (kg) *</label>
+            <input
+              id="weightKg"
+              className={shared.formInput}
+              type="number"
+              step="0.1"
+              value={weightKg}
+              onChange={(e) => setWeightKg(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className={styles.buttonRow}>
+            <button
+              type="button"
+              className={shared.buttonSecondary}
+              onClick={handleCancel}
+              style={{ flex: 1 }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={shared.buttonPrimary}
+              disabled={saving}
+              style={{ flex: 1 }}
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+
+          <div className={styles.signOutSection}>
+            <button
+              type="button"
+              className={shared.buttonSecondary}
+              onClick={signOut}
+              style={{ width: "100%" }}
+            >
+              Sign Out
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/frontend/src/styles/ProfilePage.module.css
+++ b/frontend/src/styles/ProfilePage.module.css
@@ -17,3 +17,29 @@
   padding-top: 1.5rem;
   border-top: 1px solid #eee;
 }
+
+.fieldGroup {
+  margin-bottom: 1rem;
+}
+
+.fieldLabel {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #666;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.fieldValue {
+  display: block;
+  font-size: 1rem;
+  color: #1a1a1a;
+  padding: 0.375rem 0;
+}
+
+.buttonRow {
+  display: flex;
+  gap: 0.75rem;
+}


### PR DESCRIPTION
## Summary
Implements issue #21 — profile page defaults to read-only view, toggled to edit mode via an Edit button.

## Changes
- `ProfilePage.tsx` — two-mode state machine (`view` / `edit`); view mode renders styled text, edit mode renders form inputs
- Cancel restores previous saved values
- Save returns to view mode and updates the saved baseline
- Sign Out visible in both modes
- `ProfilePage.module.css` — new `.fieldGroup`, `.fieldLabel`, `.fieldValue` styles
- `ProfilePage.test.tsx` — 15 unit tests covering view, edit, cancel, save, and error paths
- `e2e/profile.spec.ts` — 4 E2E tests (view mode, save flow, cancel flow, Sign Out visibility)

## Closes
Closes #21