### PR TITLE
feat: email subscription toggles in profile page (#36)

### DIFF
--- a/backend/handlers/profile.py
+++ b/backend/handlers/profile.py
@@ -64,6 +64,12 @@ def _put_profile(user_id: str, event: dict[str, Any]) -> dict[str, Any]:
         if field in body:
             profile_data[field] = body[field]
 
+    subs = body.get("emailSubscriptions", {})
+    profile_data["emailSubscriptions"] = {
+        "weekly": bool(subs.get("weekly", False)),
+        "monthly": bool(subs.get("monthly", False)),
+    }
+
     profile_data["updatedAt"] = datetime.now(timezone.utc).isoformat()
 
     result = put_profile(user_id, profile_data)

--- a/backend/handlers/utils/validation.py
+++ b/backend/handlers/utils/validation.py
@@ -47,6 +47,15 @@ def validate_profile(body: dict[str, Any]) -> list[str]:
         if not isinstance(body["weightKg"], (int, float)) or body["weightKg"] <= 0:
             errors.append("weightKg must be a positive number")
 
+    if "emailSubscriptions" in body:
+        subs = body["emailSubscriptions"]
+        if not isinstance(subs, dict):
+            errors.append("emailSubscriptions must be an object")
+        else:
+            for key in ("weekly", "monthly"):
+                if key in subs and not isinstance(subs[key], bool):
+                    errors.append(f"emailSubscriptions.{key} must be a boolean")
+
     return errors
 
 

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -158,6 +158,49 @@ def test_put_profile_email_stored(mock_put: object) -> None:
     assert profile_data["email"] == "user@example.com"
 
 
+@patch("handlers.profile.put_profile")
+def test_put_profile_email_subscriptions_stored(mock_put: object) -> None:
+    """emailSubscriptions field should be stored when sent."""
+    body = {**VALID_PROFILE, "emailSubscriptions": {"weekly": True, "monthly": False}}
+    mock_put.return_value = body
+    handler(_make_event("PUT", body), None)
+    profile_data = mock_put.call_args[0][1]
+    assert profile_data["emailSubscriptions"] == {"weekly": True, "monthly": False}
+
+
+@patch("handlers.profile.put_profile")
+def test_put_profile_email_subscriptions_defaults(mock_put: object) -> None:
+    """emailSubscriptions defaults to both false when not sent."""
+    mock_put.return_value = VALID_PROFILE
+    handler(_make_event("PUT", VALID_PROFILE), None)
+    profile_data = mock_put.call_args[0][1]
+    assert profile_data["emailSubscriptions"] == {"weekly": False, "monthly": False}
+
+
+def test_put_profile_email_subscriptions_invalid_type() -> None:
+    """emailSubscriptions must be an object."""
+    body = {**VALID_PROFILE, "emailSubscriptions": "not-an-object"}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "emailSubscriptions must be an object" in json.loads(response["body"])["error"]
+
+
+def test_put_profile_email_subscriptions_invalid_weekly() -> None:
+    """emailSubscriptions.weekly must be a boolean."""
+    body = {**VALID_PROFILE, "emailSubscriptions": {"weekly": "yes", "monthly": False}}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "emailSubscriptions.weekly must be a boolean" in json.loads(response["body"])["error"]
+
+
+def test_put_profile_email_subscriptions_invalid_monthly() -> None:
+    """emailSubscriptions.monthly must be a boolean."""
+    body = {**VALID_PROFILE, "emailSubscriptions": {"weekly": True, "monthly": 1}}
+    response = handler(_make_event("PUT", body), None)
+    assert response["statusCode"] == 400
+    assert "emailSubscriptions.monthly must be a boolean" in json.loads(response["body"])["error"]
+
+
 def test_put_profile_missing_all_required() -> None:
     response = handler(_make_event("PUT", {}), None)
     assert response["statusCode"] == 400

--- a/backend/tests/test_profile_data.py
+++ b/backend/tests/test_profile_data.py
@@ -153,6 +153,38 @@ def test_put_profile_strips_keys(mock_get_table: MagicMock) -> None:
     assert "sk" not in result
 
 
+@patch("data.profile.get_table")
+def test_get_profile_with_email_subscriptions(mock_get_table: MagicMock) -> None:
+    """get_profile returns emailSubscriptions nested dict correctly."""
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {
+            "userId": "user-1",
+            "sk": "PROFILE",
+            "email": "u@example.com",
+            "emailSubscriptions": {"weekly": True, "monthly": False},
+        }
+    }
+    mock_get_table.return_value = mock_table
+
+    profile = get_profile("user-1")
+    assert profile is not None
+    assert profile["emailSubscriptions"] == {"weekly": True, "monthly": False}
+    json.dumps(profile)
+
+
+@patch("data.profile.get_table")
+def test_put_profile_with_email_subscriptions(mock_get_table: MagicMock) -> None:
+    """put_profile stores and returns emailSubscriptions correctly."""
+    mock_table = MagicMock()
+    mock_get_table.return_value = mock_table
+
+    data = {"email": "u@example.com", "emailSubscriptions": {"weekly": True, "monthly": False}}
+    result = put_profile("user-1", data)
+    assert result["emailSubscriptions"] == {"weekly": True, "monthly": False}
+    json.dumps(result)
+
+
 # --- End-to-end handler test with real Decimal path ---
 
 

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -60,12 +60,44 @@ describe("ProfilePage", () => {
       expect(screen.getByTestId("view-weightKg")).toHaveTextContent("75");
     });
 
+    it("displays email subscription state as read-only text", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      expect(screen.getByTestId("view-weeklyEmail")).toHaveTextContent("Weekly: Off");
+      expect(screen.getByTestId("view-monthlyEmail")).toHaveTextContent("Monthly: Off");
+    });
+
+    it("displays subscription state from profile data", async () => {
+      const { getProfile } = await import("../api/client");
+      (getProfile as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        email: "test@example.com",
+        displayName: "Test User",
+        weightKg: 75,
+        heightCm: 180,
+        emailSubscriptions: { weekly: true, monthly: true },
+      });
+      renderPage();
+      await waitForLoaded();
+
+      expect(screen.getByTestId("view-weeklyEmail")).toHaveTextContent("Weekly: On");
+      expect(screen.getByTestId("view-monthlyEmail")).toHaveTextContent("Monthly: On");
+    });
+
     it("does not render form inputs in view mode", async () => {
       renderPage();
       await waitForLoaded();
 
       expect(screen.queryByLabelText("Email *")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Display Name *")).not.toBeInTheDocument();
+    });
+
+    it("does not render subscription checkboxes in view mode", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      expect(screen.queryByLabelText("Weekly summary email")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Monthly summary email")).not.toBeInTheDocument();
     });
 
     it("renders Edit button", async () => {
@@ -113,6 +145,46 @@ describe("ProfilePage", () => {
       expect(screen.getByLabelText("Weight (kg) *")).toHaveValue(75);
     });
 
+    it("renders email subscription toggles in edit mode", async () => {
+      await enterEditMode();
+
+      expect(screen.getByLabelText("Weekly summary email")).toBeInTheDocument();
+      expect(screen.getByLabelText("Monthly summary email")).toBeInTheDocument();
+    });
+
+    it("email subscription toggles default to unchecked", async () => {
+      await enterEditMode();
+
+      expect(screen.getByLabelText("Weekly summary email")).not.toBeChecked();
+      expect(screen.getByLabelText("Monthly summary email")).not.toBeChecked();
+    });
+
+    it("populates email subscription toggles from profile data", async () => {
+      const { getProfile } = await import("../api/client");
+      (getProfile as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        email: "test@example.com",
+        displayName: "Test User",
+        weightKg: 75,
+        heightCm: 180,
+        emailSubscriptions: { weekly: true, monthly: true },
+      });
+      renderPage();
+      await waitForLoaded();
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+      expect(screen.getByLabelText("Weekly summary email")).toBeChecked();
+      expect(screen.getByLabelText("Monthly summary email")).toBeChecked();
+    });
+
+    it("toggles weekly email subscription", async () => {
+      await enterEditMode();
+
+      const weeklyToggle = screen.getByLabelText("Weekly summary email");
+      expect(weeklyToggle).not.toBeChecked();
+      fireEvent.click(weeklyToggle);
+      expect(weeklyToggle).toBeChecked();
+    });
+
     it("shows Save and Cancel buttons", async () => {
       await enterEditMode();
 
@@ -155,6 +227,21 @@ describe("ProfilePage", () => {
       expect(screen.getByTestId("view-displayName")).toHaveTextContent("Test User");
       expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
     });
+
+    it("restores email subscription toggles on cancel", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+      const weeklyToggle = screen.getByLabelText("Weekly summary email");
+      fireEvent.click(weeklyToggle);
+      expect(weeklyToggle).toBeChecked();
+
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      // Back in view mode with original subscription state
+      expect(screen.getByTestId("view-weeklyEmail")).toHaveTextContent("Weekly: Off");
+    });
   });
 
   describe("save", () => {
@@ -179,9 +266,30 @@ describe("ProfilePage", () => {
         displayName: "New Name",
         heightCm: 180,
         weightKg: 75,
+        emailSubscriptions: { weekly: false, monthly: false },
       });
       expect(screen.getByText("Profile saved!")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+
+    it("sends emailSubscriptions on save", async () => {
+      renderPage();
+      await waitForLoaded();
+
+      fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+      const weeklyToggle = screen.getByLabelText("Weekly summary email");
+      fireEvent.click(weeklyToggle);
+
+      const form = screen.getByRole("button", { name: "Save" }).closest("form") as HTMLFormElement;
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(mockUpdateProfile).toHaveBeenCalledWith(
+          expect.objectContaining({
+            emailSubscriptions: { weekly: true, monthly: false },
+          })
+        );
+      });
     });
 
     it("shows validation error for invalid email on save", async () => {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -13,6 +13,8 @@ export function ProfilePage() {
   const [displayName, setDisplayName] = useState("");
   const [weightKg, setWeightKg] = useState("");
   const [heightCm, setHeightCm] = useState("");
+  const [weeklyEmail, setWeeklyEmail] = useState(false);
+  const [monthlyEmail, setMonthlyEmail] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -25,6 +27,8 @@ export function ProfilePage() {
     displayName: "",
     weightKg: "",
     heightCm: "",
+    weeklyEmail: false,
+    monthlyEmail: false,
   });
 
   useEffect(() => {
@@ -35,11 +39,15 @@ export function ProfilePage() {
           displayName: profile.displayName ?? "",
           weightKg: profile.weightKg?.toString() ?? "",
           heightCm: profile.heightCm?.toString() ?? "",
+          weeklyEmail: profile.emailSubscriptions?.weekly ?? false,
+          monthlyEmail: profile.emailSubscriptions?.monthly ?? false,
         };
         setEmail(values.email);
         setDisplayName(values.displayName);
         setWeightKg(values.weightKg);
         setHeightCm(values.heightCm);
+        setWeeklyEmail(values.weeklyEmail);
+        setMonthlyEmail(values.monthlyEmail);
         setSavedValues(values);
       })
       .catch((err: unknown) => {
@@ -79,6 +87,10 @@ export function ProfilePage() {
       displayName: displayName.trim(),
       heightCm: Number(heightCm),
       weightKg: Number(weightKg),
+      emailSubscriptions: {
+        weekly: weeklyEmail,
+        monthly: monthlyEmail,
+      },
     };
 
     try {
@@ -88,6 +100,8 @@ export function ProfilePage() {
         displayName: data.displayName,
         weightKg: data.weightKg.toString(),
         heightCm: data.heightCm.toString(),
+        weeklyEmail: weeklyEmail,
+        monthlyEmail: monthlyEmail,
       };
       setSavedValues(newSaved);
       setSuccess(true);
@@ -111,6 +125,8 @@ export function ProfilePage() {
     setDisplayName(savedValues.displayName);
     setWeightKg(savedValues.weightKg);
     setHeightCm(savedValues.heightCm);
+    setWeeklyEmail(savedValues.weeklyEmail);
+    setMonthlyEmail(savedValues.monthlyEmail);
     setError(null);
     setSuccess(false);
     setMode("view");
@@ -153,6 +169,12 @@ export function ProfilePage() {
           <div className={styles.fieldGroup}>
             <span className={styles.fieldLabel}>Weight (kg)</span>
             <span className={styles.fieldValue} data-testid="view-weightKg">{weightKg || "—"}</span>
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <span className={styles.fieldLabel}>Email Subscriptions</span>
+            <span className={styles.fieldValue} data-testid="view-weeklyEmail">Weekly: {weeklyEmail ? "On" : "Off"}</span>
+            <span className={styles.fieldValue} data-testid="view-monthlyEmail">Monthly: {monthlyEmail ? "On" : "Off"}</span>
           </div>
 
           <button
@@ -226,6 +248,26 @@ export function ProfilePage() {
               onChange={(e) => setWeightKg(e.target.value)}
               required
             />
+          </div>
+
+          <div className={shared.formGroup}>
+            <label className={shared.formLabel}>Email Subscriptions</label>
+            <label className={styles.toggleLabel}>
+              <input
+                type="checkbox"
+                checked={weeklyEmail}
+                onChange={(e) => setWeeklyEmail(e.target.checked)}
+              />
+              Weekly summary email
+            </label>
+            <label className={styles.toggleLabel}>
+              <input
+                type="checkbox"
+                checked={monthlyEmail}
+                onChange={(e) => setMonthlyEmail(e.target.checked)}
+              />
+              Monthly summary email
+            </label>
           </div>
 
           <div className={styles.buttonRow}>

--- a/frontend/src/styles/ProfilePage.module.css
+++ b/frontend/src/styles/ProfilePage.module.css
@@ -12,6 +12,15 @@
   color: #2e7d32;
 }
 
+.toggleLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
 .signOutSection {
   margin-top: 2rem;
   padding-top: 1.5rem;

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -1,7 +1,13 @@
+export interface EmailSubscriptions {
+  weekly: boolean;
+  monthly: boolean;
+}
+
 export interface Profile {
   email: string;
   displayName: string;
   heightCm: number;
   weightKg: number;
+  emailSubscriptions?: EmailSubscriptions;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary
Implements issue #36 — weekly and monthly email subscription toggles on the profile page.

## Changes
**Backend:**
- `types/profile.ts` — `emailSubscriptions: { weekly: bool, monthly: bool }` field on Profile type
- `validation.py` — validates `emailSubscriptions` field (both flags must be booleans)
- `profile.py` handler — reads/writes `emailSubscriptions` from profile data
- `test_profile.py` — 5 new tests: stored, defaults, invalid type, invalid weekly, invalid monthly
- `test_profile_data.py` — 2 new tests: get/put with emailSubscriptions

**Frontend:**
- `profile.ts` types — `emailSubscriptions` added to Profile interface
- `ProfilePage.tsx` — two toggle switches (weekly + monthly), visible in both view and edit modes
- `ProfilePage.module.css` — toggle styling
- `ProfilePage.test.tsx` — 5 new tests: renders toggles, defaults to unchecked, populates from profile, toggle interaction, saves with profile

## Closes
Closes #36