### PR TITLE
feat: dashboard stats summary cards (week + month) (#27)

### DIFF
--- a/frontend/e2e/stats-cards.spec.ts
+++ b/frontend/e2e/stats-cards.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "./fixtures/auth";
+
+const mockStatsResponse = {
+  currentWeek: {
+    totalDistanceMeters: 15000,
+    totalDurationSeconds: 5400,
+    runCount: 3,
+    avgPaceSecondsPerKm: 360,
+  },
+  previousWeek: {
+    totalDistanceMeters: 10000,
+    totalDurationSeconds: 4000,
+    runCount: 2,
+    avgPaceSecondsPerKm: 400,
+  },
+  currentMonth: {
+    totalDistanceMeters: 50000,
+    totalDurationSeconds: 18000,
+    runCount: 10,
+    avgPaceSecondsPerKm: 360,
+  },
+  previousMonth: {
+    totalDistanceMeters: 40000,
+    totalDurationSeconds: 16000,
+    runCount: 8,
+    avgPaceSecondsPerKm: 400,
+  },
+  weeklyDistances: [],
+  monthlyDistances: [],
+  personalRecords: {
+    longestRunMeters: 10000,
+    fastestPaceSecondsPerKm: 300,
+    mostDistanceInWeekMeters: 20000,
+    mostRunsInWeek: 5,
+  },
+  allTime: {
+    totalDistanceMeters: 100000,
+    totalRuns: 25,
+    totalDurationSeconds: 36000,
+  },
+};
+
+const emptyStatsResponse = {
+  ...mockStatsResponse,
+  currentWeek: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+  previousWeek: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+  currentMonth: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+  previousMonth: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+};
+
+test.describe("Stats Cards", () => {
+  test("displays stats cards with week and month data", async ({ authenticatedPage }) => {
+    await authenticatedPage.route("**/stats", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockStatsResponse),
+      })
+    );
+    await authenticatedPage.route("**/runs", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      })
+    );
+
+    await authenticatedPage.goto("/");
+    const statsCards = authenticatedPage.getByTestId("stats-cards");
+    await expect(statsCards).toBeVisible();
+    await expect(authenticatedPage.getByText("This Week")).toBeVisible();
+    await expect(authenticatedPage.getByText("This Month")).toBeVisible();
+  });
+
+  test("shows loading skeleton before stats load", async ({ authenticatedPage }) => {
+    await authenticatedPage.route("**/stats", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockStatsResponse),
+      });
+    });
+    await authenticatedPage.route("**/runs", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      })
+    );
+
+    await authenticatedPage.goto("/");
+    await expect(authenticatedPage.getByTestId("stats-loading")).toBeVisible();
+  });
+
+  test("shows empty state for new user with no runs", async ({ authenticatedPage }) => {
+    await authenticatedPage.route("**/stats", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(emptyStatsResponse),
+      })
+    );
+    await authenticatedPage.route("**/runs", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      })
+    );
+
+    await authenticatedPage.goto("/");
+    await expect(authenticatedPage.getByTestId("stats-empty")).toBeVisible();
+    await expect(authenticatedPage.getByText(/no stats yet/i)).toBeVisible();
+  });
+
+  test("displays comparison percentages", async ({ authenticatedPage }) => {
+    await authenticatedPage.route("**/stats", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockStatsResponse),
+      })
+    );
+    await authenticatedPage.route("**/runs", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      })
+    );
+
+    await authenticatedPage.goto("/");
+    await expect(authenticatedPage.getByTestId("stats-cards")).toBeVisible();
+    // Week distance: 15000 vs 10000 = +50%
+    const distanceCards = authenticatedPage.getByTestId("stat-card-distance").first();
+    await expect(distanceCards).toContainText("+50%");
+  });
+});

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -5,6 +5,7 @@ import { Dashboard } from "../pages/Dashboard";
 import type { Run } from "../types/run";
 
 const mockListRuns = vi.fn();
+const mockGetStats = vi.fn();
 
 beforeAll(() => {
   vi.mock("maplibre-gl", () => {
@@ -32,6 +33,7 @@ beforeAll(() => {
 
   vi.mock("../api/client", () => ({
     listRuns: (...args: unknown[]) => mockListRuns(...args),
+    getStats: (...args: unknown[]) => mockGetStats(...args),
   }));
 
   vi.mock("../auth/AuthProvider", () => ({
@@ -81,6 +83,17 @@ function renderDashboard() {
 describe("Dashboard map integration", () => {
   beforeEach(() => {
     mockListRuns.mockReset();
+    mockGetStats.mockReset();
+    mockGetStats.mockResolvedValue({
+      currentWeek: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+      previousWeek: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+      currentMonth: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+      previousMonth: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+      weeklyDistances: [],
+      monthlyDistances: [],
+      personalRecords: { longestRunMeters: 0, fastestPaceSecondsPerKm: 0, mostDistanceInWeekMeters: 0, mostRunsInWeek: 0 },
+      allTime: { totalDistanceMeters: 0, totalRuns: 0, totalDurationSeconds: 0 },
+    });
   });
 
   it("renders RouteMap for runs with route data", async () => {

--- a/frontend/src/__tests__/StatsCards.test.tsx
+++ b/frontend/src/__tests__/StatsCards.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { StatsCards } from "../components/Dashboard/StatsCards";
+import type { Stats } from "../types/stats";
+
+const mockGetStats = vi.fn();
+
+beforeAll(() => {
+  vi.mock("../api/client", () => ({
+    getStats: (...args: unknown[]) => mockGetStats(...args),
+  }));
+});
+
+const mockStats: Stats = {
+  currentWeek: {
+    totalDistanceMeters: 15000,
+    totalDurationSeconds: 5400,
+    runCount: 3,
+    avgPaceSecondsPerKm: 360,
+  },
+  previousWeek: {
+    totalDistanceMeters: 10000,
+    totalDurationSeconds: 4000,
+    runCount: 2,
+    avgPaceSecondsPerKm: 400,
+  },
+  currentMonth: {
+    totalDistanceMeters: 50000,
+    totalDurationSeconds: 18000,
+    runCount: 10,
+    avgPaceSecondsPerKm: 360,
+  },
+  previousMonth: {
+    totalDistanceMeters: 40000,
+    totalDurationSeconds: 16000,
+    runCount: 8,
+    avgPaceSecondsPerKm: 400,
+  },
+  weeklyDistances: [],
+  monthlyDistances: [],
+  personalRecords: {
+    longestRunMeters: 10000,
+    fastestPaceSecondsPerKm: 300,
+    mostDistanceInWeekMeters: 20000,
+    mostRunsInWeek: 5,
+  },
+  allTime: {
+    totalDistanceMeters: 100000,
+    totalRuns: 25,
+    totalDurationSeconds: 36000,
+  },
+};
+
+describe("StatsCards", () => {
+  beforeEach(() => {
+    mockGetStats.mockReset();
+  });
+
+  it("shows loading skeleton while fetching stats", () => {
+    mockGetStats.mockReturnValue(new Promise(() => {}));
+    render(<StatsCards />);
+    expect(screen.getByTestId("stats-loading")).toBeInTheDocument();
+  });
+
+  it("shows empty state when all periods have zero runs", async () => {
+    const emptyStats: Stats = {
+      ...mockStats,
+      currentWeek: { ...mockStats.currentWeek, runCount: 0, totalDistanceMeters: 0, totalDurationSeconds: 0, avgPaceSecondsPerKm: 0 },
+      previousWeek: { ...mockStats.previousWeek, runCount: 0, totalDistanceMeters: 0, totalDurationSeconds: 0, avgPaceSecondsPerKm: 0 },
+      currentMonth: { ...mockStats.currentMonth, runCount: 0, totalDistanceMeters: 0, totalDurationSeconds: 0, avgPaceSecondsPerKm: 0 },
+      previousMonth: { ...mockStats.previousMonth, runCount: 0, totalDistanceMeters: 0, totalDurationSeconds: 0, avgPaceSecondsPerKm: 0 },
+    };
+    mockGetStats.mockResolvedValue(emptyStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-empty")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/no stats yet/i)).toBeInTheDocument();
+  });
+
+  it("renders week and month period titles", async () => {
+    mockGetStats.mockResolvedValue(mockStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+    expect(screen.getByText("This Week")).toBeInTheDocument();
+    expect(screen.getByText("This Month")).toBeInTheDocument();
+  });
+
+  it("displays correct distance values", async () => {
+    mockGetStats.mockResolvedValue(mockStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    // 15000m = 15.0km for week, 50000m = 50.0km for month
+    const distanceCards = screen.getAllByTestId("stat-card-distance");
+    expect(distanceCards[0]).toHaveTextContent("15.0");
+    expect(distanceCards[1]).toHaveTextContent("50.0");
+  });
+
+  it("displays correct run counts", async () => {
+    mockGetStats.mockResolvedValue(mockStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    const runCards = screen.getAllByTestId("stat-card-runs");
+    expect(runCards[0]).toHaveTextContent("3");
+    expect(runCards[1]).toHaveTextContent("10");
+  });
+
+  it("displays formatted duration", async () => {
+    mockGetStats.mockResolvedValue(mockStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    const timeCards = screen.getAllByTestId("stat-card-time");
+    // 5400s = 1:30:00
+    expect(timeCards[0]).toHaveTextContent("1:30:00");
+  });
+
+  it("displays formatted pace", async () => {
+    mockGetStats.mockResolvedValue(mockStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    const paceCards = screen.getAllByTestId("stat-card-pace");
+    // 360 seconds/km = 6:00
+    expect(paceCards[0]).toHaveTextContent("6:00");
+  });
+
+  it("shows positive comparison with up arrow for increased distance", async () => {
+    mockGetStats.mockResolvedValue(mockStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    // Week distance: 15000 vs 10000 = +50%
+    const distanceCards = screen.getAllByTestId("stat-card-distance");
+    expect(distanceCards[0]).toHaveTextContent("+50%");
+  });
+
+  it("shows comparison for runs", async () => {
+    mockGetStats.mockResolvedValue(mockStats);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    // Week runs: 3 vs 2 = +50%
+    const runCards = screen.getAllByTestId("stat-card-runs");
+    expect(runCards[0]).toHaveTextContent("+50%");
+  });
+
+  it("renders nothing when API returns error", async () => {
+    mockGetStats.mockRejectedValue(new Error("Network error"));
+    const { container } = render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("stats-loading")).not.toBeInTheDocument();
+    });
+
+    // Should render nothing on error
+    expect(screen.queryByTestId("stats-cards")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("stats-empty")).not.toBeInTheDocument();
+  });
+
+  it("shows 'New' when previous period has zero distance but current has data", async () => {
+    const statsWithNoPrevious: Stats = {
+      ...mockStats,
+      previousWeek: { totalDistanceMeters: 0, totalDurationSeconds: 0, runCount: 0, avgPaceSecondsPerKm: 0 },
+    };
+    mockGetStats.mockResolvedValue(statsWithNoPrevious);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    const distanceCards = screen.getAllByTestId("stat-card-distance");
+    expect(distanceCards[0]).toHaveTextContent("New");
+  });
+
+  it("shows '--' for pace when avgPaceSecondsPerKm is 0", async () => {
+    const statsWithZeroPace: Stats = {
+      ...mockStats,
+      currentWeek: { ...mockStats.currentWeek, avgPaceSecondsPerKm: 0 },
+    };
+    mockGetStats.mockResolvedValue(statsWithZeroPace);
+    render(<StatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stats-cards")).toBeInTheDocument();
+    });
+
+    const paceCards = screen.getAllByTestId("stat-card-pace");
+    expect(paceCards[0]).toHaveTextContent("--");
+  });
+});

--- a/frontend/src/components/Dashboard/StatsCards.module.css
+++ b/frontend/src/components/Dashboard/StatsCards.module.css
@@ -1,0 +1,123 @@
+.statsSection {
+  padding: 0 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .statsGrid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.periodTitle {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0.75rem 0 0.375rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.75rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.cardValue {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  line-height: 1.2;
+}
+
+.cardLabel {
+  font-size: 0.6875rem;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.125rem;
+}
+
+.comparison {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  margin-top: 0.25rem;
+}
+
+.comparisonUp {
+  composes: comparison;
+  color: #2e7d32;
+}
+
+.comparisonDown {
+  composes: comparison;
+  color: #d32f2f;
+}
+
+.comparisonNeutral {
+  composes: comparison;
+  color: #999;
+}
+
+/* Loading skeleton */
+.skeletonCard {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.75rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.skeletonLine {
+  background: linear-gradient(90deg, #eee 25%, #e0e0e0 50%, #eee 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 4px;
+}
+
+.skeletonValue {
+  composes: skeletonLine;
+  height: 1.25rem;
+  width: 60%;
+  margin-bottom: 0.375rem;
+}
+
+.skeletonLabel {
+  composes: skeletonLine;
+  height: 0.625rem;
+  width: 80%;
+  margin-bottom: 0.25rem;
+}
+
+.skeletonComparison {
+  composes: skeletonLine;
+  height: 0.625rem;
+  width: 40%;
+}
+
+.skeletonTitle {
+  composes: skeletonLine;
+  height: 0.875rem;
+  width: 120px;
+  margin: 0.75rem 0 0.375rem;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Empty state */
+.emptyState {
+  text-align: center;
+  color: #999;
+  padding: 1.5rem 1rem;
+  font-size: 0.875rem;
+}

--- a/frontend/src/components/Dashboard/StatsCards.tsx
+++ b/frontend/src/components/Dashboard/StatsCards.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from "react";
+import { getStats } from "../../api/client";
+import { formatDuration, formatPace } from "../../utils/format";
+import type { Stats, PeriodSummary } from "../../types/stats";
+import styles from "./StatsCards.module.css";
+
+function formatDistance(meters: number): string {
+  return (meters / 1000).toFixed(1);
+}
+
+function formatAvgPace(secondsPerKm: number): string {
+  if (secondsPerKm <= 0) return "--";
+  return formatPace(secondsPerKm).replace(" /km", "");
+}
+
+interface ComparisonResult {
+  label: string;
+  direction: "up" | "down" | "neutral";
+}
+
+function computeComparison(current: number, previous: number): ComparisonResult {
+  if (previous === 0 && current === 0) {
+    return { label: "--", direction: "neutral" };
+  }
+  if (previous === 0) {
+    return { label: "New", direction: "up" };
+  }
+  const pct = Math.round(((current - previous) / previous) * 100);
+  if (pct === 0) {
+    return { label: "0%", direction: "neutral" };
+  }
+  if (pct > 0) {
+    return { label: `+${pct}%`, direction: "up" };
+  }
+  return { label: `${pct}%`, direction: "down" };
+}
+
+function comparisonClassName(direction: "up" | "down" | "neutral"): string {
+  if (direction === "up") return styles.comparisonUp;
+  if (direction === "down") return styles.comparisonDown;
+  return styles.comparisonNeutral;
+}
+
+function comparisonArrow(direction: "up" | "down" | "neutral"): string {
+  if (direction === "up") return "\u2191";
+  if (direction === "down") return "\u2193";
+  return "";
+}
+
+interface PeriodCardsProps {
+  title: string;
+  current: PeriodSummary;
+  previous: PeriodSummary;
+}
+
+function PeriodCards({ title, current, previous }: PeriodCardsProps) {
+  const distComp = computeComparison(current.totalDistanceMeters, previous.totalDistanceMeters);
+  const runsComp = computeComparison(current.runCount, previous.runCount);
+  const timeComp = computeComparison(current.totalDurationSeconds, previous.totalDurationSeconds);
+  // For pace, lower is better, so invert direction
+  const paceComp = computeComparison(previous.avgPaceSecondsPerKm, current.avgPaceSecondsPerKm);
+
+  return (
+    <>
+      <div className={styles.periodTitle} data-testid={`period-title-${title.toLowerCase().replace(/\s/g, "-")}`}>
+        {title}
+      </div>
+      <div className={styles.statsGrid}>
+        <div className={styles.card} data-testid="stat-card-distance">
+          <div className={styles.cardValue}>{formatDistance(current.totalDistanceMeters)}</div>
+          <div className={styles.cardLabel}>km</div>
+          <div className={comparisonClassName(distComp.direction)}>
+            {comparisonArrow(distComp.direction)} {distComp.label}
+          </div>
+        </div>
+        <div className={styles.card} data-testid="stat-card-runs">
+          <div className={styles.cardValue}>{current.runCount}</div>
+          <div className={styles.cardLabel}>runs</div>
+          <div className={comparisonClassName(runsComp.direction)}>
+            {comparisonArrow(runsComp.direction)} {runsComp.label}
+          </div>
+        </div>
+        <div className={styles.card} data-testid="stat-card-time">
+          <div className={styles.cardValue}>{formatDuration(current.totalDurationSeconds)}</div>
+          <div className={styles.cardLabel}>time</div>
+          <div className={comparisonClassName(timeComp.direction)}>
+            {comparisonArrow(timeComp.direction)} {timeComp.label}
+          </div>
+        </div>
+        <div className={styles.card} data-testid="stat-card-pace">
+          <div className={styles.cardValue}>{formatAvgPace(current.avgPaceSecondsPerKm)}</div>
+          <div className={styles.cardLabel}>avg pace /km</div>
+          <div className={comparisonClassName(paceComp.direction)}>
+            {comparisonArrow(paceComp.direction)} {paceComp.label}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className={styles.statsSection} data-testid="stats-loading">
+      {[0, 1].map((i) => (
+        <div key={i}>
+          <div className={styles.skeletonTitle} />
+          <div className={styles.statsGrid}>
+            {[0, 1, 2, 3].map((j) => (
+              <div key={j} className={styles.skeletonCard}>
+                <div className={styles.skeletonValue} />
+                <div className={styles.skeletonLabel} />
+                <div className={styles.skeletonComparison} />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className={styles.statsSection} data-testid="stats-empty">
+      <div className={styles.emptyState}>
+        No stats yet. Complete your first run to see your progress!
+      </div>
+    </div>
+  );
+}
+
+export function StatsCards() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getStats()
+      .then((data) => {
+        if (!cancelled) setStats(data);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (error) {
+    return null;
+  }
+
+  if (!stats || (stats.currentWeek.runCount === 0 && stats.currentMonth.runCount === 0 &&
+      stats.previousWeek.runCount === 0 && stats.previousMonth.runCount === 0)) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className={styles.statsSection} data-testid="stats-cards">
+      <PeriodCards title="This Week" current={stats.currentWeek} previous={stats.previousWeek} />
+      <PeriodCards title="This Month" current={stats.currentMonth} previous={stats.previousMonth} />
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,55 +3,11 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthProvider";
 import { listRuns } from "../api/client";
 import { RouteMap } from "../components/Map/RouteMap";
+import { StatsCards } from "../components/Dashboard/StatsCards";
 import { formatDuration, formatPace, formatDate, formatDateTime, formatCalories, formatAudio } from "../utils/format";
 import type { Run } from "../types/run";
 import shared from "../styles/shared.module.css";
 import styles from "../styles/Dashboard.module.css";
-
-function getWeekStart(): Date {
-  const now = new Date();
-  const day = now.getDay();
-  const diff = day === 0 ? 6 : day - 1;
-  const monday = new Date(now);
-  monday.setHours(0, 0, 0, 0);
-  monday.setDate(monday.getDate() - diff);
-  return monday;
-}
-
-interface WeeklyStats {
-  runCount: number;
-  totalDistanceKm: number;
-  totalCalories: number;
-  avgPaceSecondsPerKm: number | null;
-}
-
-function computeWeeklyStats(runs: Run[]): WeeklyStats {
-  const weekStart = getWeekStart();
-  const weekRuns = runs.filter(
-    (r) => r.status === "completed" && new Date(r.runDate) >= weekStart
-  );
-  const totalDistanceKm = weekRuns.reduce(
-    (sum, r) => sum + (r.distanceMeters ?? 0) / 1000,
-    0
-  );
-  const totalCalories = weekRuns.reduce(
-    (sum, r) => sum + (r.caloriesBurned ?? 0),
-    0
-  );
-  const paces = weekRuns
-    .map((r) => r.paceSecondsPerKm)
-    .filter((p): p is number => p !== undefined && p > 0);
-  const avgPace = paces.length > 0
-    ? paces.reduce((a, b) => a + b, 0) / paces.length
-    : null;
-
-  return {
-    runCount: weekRuns.length,
-    totalDistanceKm,
-    totalCalories,
-    avgPaceSecondsPerKm: avgPace,
-  };
-}
 
 export function Dashboard() {
   const { user } = useAuth();
@@ -84,8 +40,6 @@ export function Dashboard() {
     [runs]
   );
 
-  const weekly = useMemo(() => computeWeeklyStats(runs), [runs]);
-
   if (loading) {
     return (
       <div className={shared.page}>
@@ -110,32 +64,7 @@ export function Dashboard() {
         </h1>
       </div>
 
-      <div className={styles.weeklyStats}>
-        <div className={styles.statCard}>
-          <div className={styles.statIcon}>🏃</div>
-          <div className={styles.statValue}>{weekly.runCount}</div>
-          <div className={styles.statLabel}>Runs this week</div>
-        </div>
-        <div className={styles.statCard}>
-          <div className={styles.statIcon}>📏</div>
-          <div className={styles.statValue}>{weekly.totalDistanceKm.toFixed(1)}</div>
-          <div className={styles.statLabel}>km this week</div>
-        </div>
-        <div className={styles.statCard}>
-          <div className={styles.statIcon}>🔥</div>
-          <div className={styles.statValue}>{Math.round(weekly.totalCalories)}</div>
-          <div className={styles.statLabel}>kcal burned</div>
-        </div>
-        <div className={styles.statCard}>
-          <div className={styles.statIcon}>⚡</div>
-          <div className={styles.statValue}>
-            {weekly.avgPaceSecondsPerKm
-              ? formatPace(weekly.avgPaceSecondsPerKm).replace(" /km", "")
-              : "--"}
-          </div>
-          <div className={styles.statLabel}>avg pace /km</div>
-        </div>
-      </div>
+      <StatsCards />
 
       <h2 className={styles.sectionTitle}>Recent Runs</h2>
 


### PR DESCRIPTION
## Summary
Implements issue #27 — stats summary cards at the top of the dashboard showing key metrics for the current week and month.

## Changes
- `StatsCards.tsx` — new component with week + month cards, comparison indicators, loading skeleton, empty state
- `StatsCards.module.css` — responsive layout (side-by-side desktop, stacked mobile)
- `Dashboard.tsx` — integrates StatsCards, refactored to clean up existing stats display
- `StatsCards.test.tsx` — 12 unit tests: loading, empty, values, pace/duration formatting, comparison arrows, error state, edge cases
- `Dashboard.test.tsx` — updated smoke tests
- `e2e/stats-cards.spec.ts` — E2E tests

## Closes
Closes #27