### PR TITLE
fix: add V2 pipeline triggers for automatic GitHub push detection

### DIFF
--- a/infra/stacks/backend_pipeline_stack.py
+++ b/infra/stacks/backend_pipeline_stack.py
@@ -135,6 +135,20 @@ class BackendPipelineStack(Stack):
             self,
             "BackendPipeline",
             pipeline_name="RunMapRepeat-Backend-Pipeline",
+            pipeline_type=codepipeline.PipelineType.V2,
+            triggers=[
+                codepipeline.TriggerProps(
+                    provider_type=codepipeline.ProviderType.CODE_STAR_SOURCE_CONNECTION,
+                    git_configuration=codepipeline.GitConfiguration(
+                        source_action=source_action,
+                        push_filter=[
+                            codepipeline.GitPushFilter(
+                                branches_includes=["main"],
+                            ),
+                        ],
+                    ),
+                ),
+            ],
             stages=[
                 codepipeline.StageProps(
                     stage_name="Source",

--- a/infra/stacks/pipeline_stack.py
+++ b/infra/stacks/pipeline_stack.py
@@ -112,6 +112,20 @@ class PipelineStack(Stack):
             self,
             "FrontendPipeline",
             pipeline_name="RunMapRepeat-Frontend-Pipeline",
+            pipeline_type=codepipeline.PipelineType.V2,
+            triggers=[
+                codepipeline.TriggerProps(
+                    provider_type=codepipeline.ProviderType.CODE_STAR_SOURCE_CONNECTION,
+                    git_configuration=codepipeline.GitConfiguration(
+                        source_action=source_action,
+                        push_filter=[
+                            codepipeline.GitPushFilter(
+                                branches_includes=["main"],
+                            ),
+                        ],
+                    ),
+                ),
+            ],
             stages=[
                 codepipeline.StageProps(
                     stage_name="Source",


### PR DESCRIPTION
## Problem
Both CodePipeline V2 pipelines (frontend + backend) had no `triggers` configured. Merges to `main` never auto-started builds — all executions were manual.

## Root Cause
CodePipeline V2 requires explicit `Triggers` with `GitConfiguration` for push-based auto-detection. The CDK `CodeStarConnectionsSourceAction` default `trigger_on_push` only applies to V1-style event detection.

## Fix
Added `pipeline_type=V2` + `triggers` with `CodeStarSourceConnection` git push filter on `main` branch to both:
- `pipeline_stack.py` (frontend)
- `backend_pipeline_stack.py` (backend)

## Testing
- `cdk synth` ✅ — both templates include correct `Triggers` block
- CDK tests: 30/31 pass (1 pre-existing failure in test_api_stack unrelated to this change)

Closes #0