### PR TITLE
fix: update Lambda function count assertion to 3

### DIFF
--- a/infra/tests/test_api_stack.py
+++ b/infra/tests/test_api_stack.py
@@ -26,7 +26,7 @@ def test_rest_api_created() -> None:
 
 def test_lambda_functions_created() -> None:
     template = _create_api_stack()
-    template.resource_count_is("AWS::Lambda::Function", 2)
+    template.resource_count_is("AWS::Lambda::Function", 3)
 
 
 def test_lambda_uses_arm64() -> None:


### PR DESCRIPTION
Fixes #59

The API stack now has 3 Lambda functions (was 2 when the test was written). Updated the assertion to match reality.

**31/31 tests passing locally.**