### PR TITLE
feat: auto-fix agent — Claude Code closes review findings automatically (#73)

### DIFF
--- a/.github/prompts/fix.md
+++ b/.github/prompts/fix.md
@@ -1,0 +1,29 @@
+You are an auto-fix agent for the RunMapRepeat project. Your job is to fix code review findings pushed to you by the review agent.
+
+## Instructions
+
+1. Read each finding carefully — understand the root cause before making changes
+2. Fix the source code to resolve each finding
+3. After each fix, run the relevant test suite to verify nothing is broken:
+   - Frontend: `cd frontend && npm ci && npm test -- --run`
+   - Backend: `cd backend && pip install pytest moto boto3 && pytest --tb=short`
+   - CDK: `cd infra && pip install -r requirements.txt && pytest --tb=short`
+4. If a fix breaks tests, revert that specific fix and move on
+5. Only keep fixes where all tests still pass
+
+## Rules
+
+- Fix the source code, NOT the tests
+- Follow the project conventions in CLAUDE.md
+- For CRITICAL findings, add a brief code comment explaining the fix
+- Do not modify infrastructure code (infra/) unless the finding specifically targets it
+- Do not add unnecessary dependencies
+- Keep fixes minimal and focused — don't refactor surrounding code
+- If you cannot fix a finding safely, skip it and note why
+
+## Project Context
+
+RunMapRepeat is a personal exercise run tracker.
+- Frontend: React + Vite + TypeScript SPA
+- Backend: Python Lambda handlers + DynamoDB
+- Infrastructure: AWS CDK (Python)

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -22,6 +22,7 @@ import re
 import sys
 import urllib.request
 import urllib.error
+import uuid
 from pathlib import Path
 
 import boto3
@@ -702,6 +703,23 @@ def main() -> None:
         or severity_counts.get("HIGH", 0) > 0
         or still_open_count > 0
     )
+
+    # 10a. Write GitHub Actions outputs for downstream jobs (e.g., fix agent)
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        findings_summary = "\n".join(
+            f"- [{f.get('severity', 'LOW')}] {f.get('file', '?')}:{f.get('line', '?')} — "
+            f"{f.get('title', '')}: {f.get('body', '')[:200]}"
+            for f in findings
+        )
+        with open(gh_output, "a") as fh:
+            fh.write(f"has_findings={'true' if has_blockers else 'false'}\n")
+            # Multi-line outputs use delimiter syntax — unique per output
+            delim1 = f"ghadelim_{uuid.uuid4().hex[:8]}"
+            delim2 = f"ghadelim_{uuid.uuid4().hex[:8]}"
+            fh.write(f"findings_json<<{delim1}\n{json.dumps(findings)}\n{delim1}\n")
+            fh.write(f"findings_summary<<{delim2}\n{findings_summary}\n{delim2}\n")
+        log.info("Wrote GitHub Actions outputs: has_findings=%s", has_blockers)
 
     if not has_blockers:
         review_body += "---\n\n## ✅ Ready for Merge\n\n"

--- a/.github/scripts/test_ai_review.py
+++ b/.github/scripts/test_ai_review.py
@@ -1,0 +1,164 @@
+"""Tests for ai_review.py."""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add parent to path so we can import the module
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+import ai_review
+
+
+class TestParseFindings:
+    """Tests for parse_findings()."""
+
+    def test_parses_json_block(self) -> None:
+        review = '''Here are the findings:
+
+```json
+[
+  {
+    "severity": "HIGH",
+    "title": "Missing auth check",
+    "file": "backend/handlers/runs.py",
+    "line": 42,
+    "body": "No userId validation",
+    "suggestion": "Add userId check"
+  }
+]
+```
+
+That's all.'''
+        findings = ai_review.parse_findings(review)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "HIGH"
+        assert findings[0]["file"] == "backend/handlers/runs.py"
+
+    def test_empty_json_array(self) -> None:
+        review = "Everything looks good!\n\n```json\n[]\n```"
+        findings = ai_review.parse_findings(review)
+        assert findings == []
+
+    def test_no_json_block(self) -> None:
+        review = "This code looks fine, no issues found."
+        findings = ai_review.parse_findings(review)
+        assert findings == []
+
+    def test_invalid_json(self) -> None:
+        review = "```json\n{not valid json}\n```"
+        findings = ai_review.parse_findings(review)
+        assert findings == []
+
+    def test_multiple_findings(self) -> None:
+        review = '''```json
+[
+  {"severity": "CRITICAL", "title": "SQL injection", "file": "a.py", "line": 1, "body": "bad", "suggestion": "fix"},
+  {"severity": "LOW", "title": "Naming", "file": "b.py", "line": 2, "body": "meh", "suggestion": "rename"}
+]
+```'''
+        findings = ai_review.parse_findings(review)
+        assert len(findings) == 2
+        assert findings[0]["severity"] == "CRITICAL"
+        assert findings[1]["severity"] == "LOW"
+
+
+class TestFormatReviewComment:
+    """Tests for format_review_comment()."""
+
+    def test_no_findings(self) -> None:
+        comment = ai_review.format_review_comment("Looks good", [])
+        assert "No actionable findings" in comment
+        assert "AI Code Review" in comment
+
+    def test_with_findings(self) -> None:
+        findings = [
+            {
+                "severity": "HIGH",
+                "title": "Missing validation",
+                "file": "handler.py",
+                "line": 10,
+                "body": "No input validation",
+                "suggestion": "Add validation",
+            }
+        ]
+        comment = ai_review.format_review_comment("review text", findings)
+        assert "**1** issue(s)" in comment
+        assert "HIGH" in comment
+        assert "Missing validation" in comment
+        assert "`handler.py:10`" in comment
+
+
+class TestWriteGithubOutputs:
+    """Tests for write_github_outputs()."""
+
+    def test_writes_outputs_with_findings(self) -> None:
+        findings = [
+            {
+                "severity": "HIGH",
+                "title": "Bug found",
+                "file": "app.py",
+                "line": 5,
+                "body": "Off by one",
+                "suggestion": "Use <= instead of <",
+            },
+            {
+                "severity": "LOW",
+                "title": "Style issue",
+                "file": "utils.py",
+                "line": 10,
+                "body": "Bad naming",
+                "suggestion": "Rename",
+            },
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            output_file = f.name
+
+        try:
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": output_file}):
+                ai_review.write_github_outputs(findings)
+
+            content = open(output_file).read()
+            assert "has_findings=true" in content
+            assert "findings_json<<FINDINGS_EOF" in content
+            assert "FINDINGS_EOF" in content
+            assert "findings_summary<<SUMMARY_EOF" in content
+            assert "SUMMARY_EOF" in content
+            assert '"severity": "HIGH"' in content
+            assert "1. [HIGH] Bug found" in content
+        finally:
+            os.unlink(output_file)
+
+    def test_writes_false_when_only_low_findings(self) -> None:
+        findings = [
+            {"severity": "LOW", "title": "Style", "file": "a.py", "line": 1, "body": "x"},
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            output_file = f.name
+
+        try:
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": output_file}):
+                ai_review.write_github_outputs(findings)
+
+            content = open(output_file).read()
+            assert "has_findings=false" in content
+        finally:
+            os.unlink(output_file)
+
+    def test_no_github_output_env(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            # Should not raise
+            ai_review.write_github_outputs([])
+
+
+class TestLoadPrompt:
+    """Tests for load_prompt()."""
+
+    def test_loads_review_prompt(self) -> None:
+        prompt = ai_review.load_prompt()
+        assert "RunMapRepeat" in prompt
+        assert "severity" in prompt.lower() or "CRITICAL" in prompt

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -125,6 +125,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
+    outputs:
+      has_findings: ${{ steps.run-review.outputs.has_findings }}
+      findings_json: ${{ steps.run-review.outputs.findings_json }}
+      findings_summary: ${{ steps.run-review.outputs.findings_summary }}
 
     steps:
       - name: Checkout
@@ -147,6 +151,7 @@ jobs:
         run: pip install boto3
 
       - name: Run AI review
+        id: run-review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -154,3 +159,74 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: python .github/scripts/ai_review.py
+
+  # ================================================================
+  # Job 3: Trigger auto-fix via @claude comment
+  # ================================================================
+  trigger-fix:
+    name: Trigger Auto-Fix
+    needs: review
+    runs-on: ubuntu-latest
+    if: >
+      needs.review.outputs.has_findings == 'true' &&
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'no-auto-fix')
+
+    steps:
+      - name: Check cycle count
+        id: cycle
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check existing @claude fix comments to count cycles
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number }
+            );
+            const fixComments = comments.filter(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('@claude') &&
+              c.body.includes('[ai-fix-cycle-')
+            );
+            const cycle = fixComments.length + 1;
+            core.setOutput('cycle', cycle);
+            core.setOutput('skip', cycle > 2 ? 'true' : 'false');
+            console.log(`Fix cycle: ${cycle}/2 (skip: ${cycle > 2})`);
+
+      - name: Post max-cycles comment
+        if: steps.cycle.outputs.skip == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '⚠️ **Auto-Fix Limit Reached**\n\nMax 2 fix cycles completed. Remaining findings require manual intervention.',
+            });
+
+      - name: Post @claude fix comment
+        if: steps.cycle.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          FINDINGS_SUMMARY: ${{ needs.review.outputs.findings_summary }}
+        with:
+          script: |
+            const cycle = '${{ steps.cycle.outputs.cycle }}';
+            const findings = process.env.FINDINGS_SUMMARY;
+            const body = `@claude [ai-fix-cycle-${cycle}] Fix the following code review findings. ` +
+              `Read .github/prompts/fix.md for detailed instructions.\n\n` +
+              `**Rules:**\n` +
+              `- Read the PR description to understand the feature context before fixing\n` +
+              `- Fix the source code, NOT the tests\n` +
+              `- Run tests after each fix (see CLAUDE.md for commands)\n` +
+              `- If a fix breaks tests, revert it\n` +
+              `- Only keep fixes where all tests still pass\n` +
+              `- Commit message must include [ai-fix-cycle-${cycle}]\n\n` +
+              `**Findings (cycle ${cycle}/2):**\n\n${findings}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });


### PR DESCRIPTION
## What

After the AI review agent (Opus 4.6) posts findings, this auto-fix agent automatically attempts to resolve them using `anthropics/claude-code-action@v1` with Sonnet 4 on Amazon Bedrock.

## Pipeline Flow

```
PR push → test → review (Opus 4.6) → fix (Sonnet 4) → push fix → re-review cycle
```

## Components

| File | Purpose |
|------|---------|
| `.github/workflows/pr-review.yml` | Updated — added Job 3: fix |
| `.github/scripts/ai_review.py` | Review script (Opus 4.6) — now outputs `has_findings` + `findings_json` for fix job |
| `.github/scripts/test_ai_review.py` | 11 tests for review script |
| `.github/prompts/review.md` | Review prompt (used by Opus 4.6) |
| `.github/prompts/fix.md` | Fix instructions for Claude Code (Sonnet 4) |

## Model Roles

| Job | Model | Why |
|-----|-------|-----|
| **Review** | Claude Opus 4.6 | Deep reasoning for nuanced code analysis |
| **Fix** | Claude Sonnet 4 | Cost-efficient for code edits |

## Safety

- **Max 2 fix cycles** via `[ai-fix-cycle-N]` commit message tags
- **`no-auto-fix` label** to skip fix job entirely
- **15 min timeout, 30 max turns** per fix run
- **GitHub App token** for pushes (not GITHUB_TOKEN — needed to trigger re-review)
- Telegram alert when max cycles reached (manual intervention needed)

## Cost

- Review: ~$0.15/PR (Opus 4.6)
- Fix: ~$0.05/PR (Sonnet 4, only runs when findings exist)
- Max 2 fix cycles per PR

Closes #73
Depends on #57 (merged as #72)