### PR TITLE
fix: Add concurrency groups to CI workflows to prevent race conditions

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: claude-fix-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
## Problem

When multiple pushes happen quickly to a PR branch, multiple CI runs execute in parallel causing:
- Duplicate review comments (two `@claude` comments posted simultaneously)
- Cycle counter double-counting
- Wasted compute on stale runs
- Confusing PR conversation with duplicate test result comments

## Fix

Added `concurrency` groups with `cancel-in-progress: true`:

| Workflow | Group Key | Effect |
|----------|-----------|--------|
| `pr-review.yml` | `pr-review-{PR#}` | New push cancels in-progress review for same PR |
| `claude-fix.yml` | `claude-fix-{PR#}` | New `@claude` comment cancels in-progress fix for same PR |

This is a native GitHub Actions feature — no custom logic needed.