### PR TITLE
fix: Use browser-local timezone for date display and form defaults

### DIFF
--- a/frontend/src/pages/NewRunPage.tsx
+++ b/frontend/src/pages/NewRunPage.tsx
@@ -15,7 +15,7 @@ function toISOLocal(date: string, time: string): string {
 
 function nowDate(): string {
   const d = new Date();
-  return d.toISOString().slice(0, 10);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
 function nowTime(): string {

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -31,7 +31,7 @@ export function RunDetailPage() {
         setRun(data);
         setEditTitle(data.title ?? "");
         setEditNotes(data.notes ?? "");
-        setEditDate(data.runDate.slice(0, 10));
+        setEditDate(new Date(data.runDate).toLocaleDateString("sv-SE"));
       })
       .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false));


### PR DESCRIPTION
## Summary

Fixes timezone handling so dates display in the user's local timezone instead of UTC.

### Changes
- **NewRunPage**: `nowDate()` uses `getFullYear/getMonth/getDate` (local) instead of `toISOString().slice()` (UTC) — was off by 1 day at night for non-UTC users
- **RunDetailPage**: Edit date pre-fill uses `toLocaleDateString('sv-SE')` for local YYYY-MM-DD instead of slicing UTC ISO string

### Architecture
- **Backend**: Already stores all dates in UTC ISO strings ✅ (no changes needed)
- **Frontend display**: `formatDate`/`formatDateTime` use `Intl.DateTimeFormat` which defaults to browser timezone when `timeZone` option is omitted ✅

### Testing
- All 168 frontend tests pass

Closes #87