### PR TITLE
fix: Preserve original time when editing run date

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@playwright/test": "^1.42.0",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.0.0",
@@ -4784,6 +4785,20 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@playwright/test": "^1.42.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/__tests__/RunDetailPage.test.tsx
+++ b/frontend/src/__tests__/RunDetailPage.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { RunDetailPage } from "../pages/RunDetailPage";
 import type { Run } from "../types/run";
 
 const mockGetRun = vi.fn();
+const mockUpdateRun = vi.fn();
 
 beforeAll(() => {
   vi.mock("maplibre-gl", () => {
@@ -32,7 +34,7 @@ beforeAll(() => {
 
   vi.mock("../api/client", () => ({
     getRun: (...args: unknown[]) => mockGetRun(...args),
-    updateRun: vi.fn(),
+    updateRun: (...args: unknown[]) => mockUpdateRun(...args),
     deleteRun: vi.fn(),
     completeRun: vi.fn(),
   }));
@@ -145,5 +147,88 @@ describe("RunDetailPage audio display", () => {
 
     expect(screen.getByText("Open in Spotify")).toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});
+
+describe("RunDetailPage edit — date preservation (regression #89)", () => {
+  beforeEach(() => {
+    mockGetRun.mockReset();
+    mockUpdateRun.mockReset();
+  });
+
+  it("does not send runDate when date is unchanged", async () => {
+    const run: Run = {
+      ...baseRun,
+      runDate: "2026-03-24T07:30:00Z",
+    };
+    mockGetRun.mockResolvedValue(run);
+    mockUpdateRun.mockResolvedValue(run);
+
+    const user = userEvent.setup();
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    // Enter edit mode
+    await user.click(screen.getByText("Edit"));
+
+    // Change only the title
+    const titleInput = screen.getByLabelText("Title");
+    await user.clear(titleInput);
+    await user.type(titleInput, "Evening Run");
+
+    // Save without changing date
+    await user.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-1", {
+        title: "Evening Run",
+        notes: undefined,
+      });
+    });
+
+    // Verify runDate was NOT sent (preserves original)
+    const callArgs = mockUpdateRun.mock.calls[0][1];
+    expect(callArgs).not.toHaveProperty("runDate");
+  });
+
+  it("preserves time component when date is changed", async () => {
+    const run: Run = {
+      ...baseRun,
+      runDate: "2026-03-24T07:30:00.000Z",
+    };
+    mockGetRun.mockResolvedValue(run);
+    mockUpdateRun.mockResolvedValue({ ...run, runDate: "2026-03-25T07:30:00.000Z" });
+
+    const user = userEvent.setup();
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Edit"));
+
+    // Change the date
+    const dateInput = screen.getByLabelText("Date");
+    fireEvent.change(dateInput, { target: { value: "2026-03-25" } });
+
+    // Verify the input value actually changed
+    expect((dateInput as HTMLInputElement).value).toBe("2026-03-25");
+
+    await user.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockUpdateRun).toHaveBeenCalled();
+    });
+
+    // The sent runDate should have the new date but preserve the original time
+    const callArgs = mockUpdateRun.mock.calls[0][1];
+    expect(callArgs).toHaveProperty("runDate");
+    const sentDate = new Date(callArgs.runDate);
+    expect(sentDate.getUTCHours()).toBe(7);
+    expect(sentDate.getUTCMinutes()).toBe(30);
   });
 });

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -18,6 +18,7 @@ export function RunDetailPage() {
   const [editTitle, setEditTitle] = useState("");
   const [editNotes, setEditNotes] = useState("");
   const [editDate, setEditDate] = useState("");
+  const [originalRunDate, setOriginalRunDate] = useState("");
   const [saving, setSaving] = useState(false);
 
   const [completing, setCompleting] = useState(false);
@@ -31,6 +32,7 @@ export function RunDetailPage() {
         setRun(data);
         setEditTitle(data.title ?? "");
         setEditNotes(data.notes ?? "");
+        setOriginalRunDate(data.runDate);
         setEditDate(new Date(data.runDate).toLocaleDateString("sv-SE"));
       })
       .catch((err: Error) => setError(err.message))
@@ -41,12 +43,25 @@ export function RunDetailPage() {
     if (!runId) return;
     setSaving(true);
     try {
+      // Only send runDate if the user actually changed the date
+      let runDate: string | undefined;
+      const originalDateStr = new Date(originalRunDate).toLocaleDateString("sv-SE");
+      if (editDate && editDate !== originalDateStr) {
+        // User changed the date — preserve the original time component
+        const orig = new Date(originalRunDate);
+        const [year, month, day] = editDate.split("-").map(Number);
+        const updated = new Date(orig);
+        updated.setFullYear(year, month - 1, day);
+        runDate = updated.toISOString();
+      }
+
       const updated = await updateRun(runId, {
         title: editTitle.trim() || undefined,
         notes: editNotes.trim() || undefined,
-        runDate: editDate ? new Date(editDate).toISOString() : undefined,
+        ...(runDate !== undefined ? { runDate } : {}),
       });
       setRun(updated);
+      setOriginalRunDate(updated.runDate);
       setEditing(false);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to save";


### PR DESCRIPTION
## Summary

Fixes the date-shift bug where editing a run would silently reset the time component to UTC midnight, potentially shifting the stored date for users in positive UTC offsets.

## Root Cause

`RunDetailPage.tsx` displayed the date in local timezone (`toLocaleDateString('sv-SE')`) but saved it back as `new Date(dateOnlyString).toISOString()` — which always produces `T00:00:00Z`, losing the original time.

## Fix

- Track the `originalRunDate` ISO string
- Only include `runDate` in the PUT request if the user actually changed the date
- When the date IS changed, construct the new ISO string by updating the date components on the original Date object, preserving hours/minutes/seconds

## Tests

- **Regression test 1**: Editing title without changing date → `runDate` is NOT sent in the PUT body
- **Regression test 2**: Changing the date → sent `runDate` preserves original UTC hours/minutes

All 170 tests pass.

Closes #89