### PR TITLE
feat: Enhanced run detail view with editing and Spotify song display

### DIFF
--- a/frontend/src/__tests__/RunDetailPage.test.tsx
+++ b/frontend/src/__tests__/RunDetailPage.test.tsx
@@ -7,6 +7,8 @@ import type { Run } from "../types/run";
 
 const mockGetRun = vi.fn();
 const mockUpdateRun = vi.fn();
+const mockDeleteRun = vi.fn();
+const mockSearchSpotify = vi.fn();
 
 beforeAll(() => {
   vi.mock("maplibre-gl", () => {
@@ -35,9 +37,13 @@ beforeAll(() => {
   vi.mock("../api/client", () => ({
     getRun: (...args: unknown[]) => mockGetRun(...args),
     updateRun: (...args: unknown[]) => mockUpdateRun(...args),
-    deleteRun: vi.fn(),
-    completeRun: vi.fn(),
+    deleteRun: (...args: unknown[]) => mockDeleteRun(...args),
+    searchSpotify: (...args: unknown[]) => mockSearchSpotify(...args),
   }));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 function renderRunDetail(runId = "run-1") {
@@ -45,6 +51,7 @@ function renderRunDetail(runId = "run-1") {
     <MemoryRouter initialEntries={[`/runs/${runId}`]}>
       <Routes>
         <Route path="/runs/:runId" element={<RunDetailPage />} />
+        <Route path="/" element={<div>Home</div>} />
       </Routes>
     </MemoryRouter>
   );
@@ -60,6 +67,72 @@ const baseRun: Run = {
   distanceMeters: 5000,
   durationSeconds: 1800,
 };
+
+describe("RunDetailPage view mode", () => {
+  it("shows title, date, and stats", async () => {
+    const run: Run = {
+      ...baseRun,
+      paceSecondsPerKm: 360,
+      caloriesBurned: 420,
+      elevationGainMeters: 85,
+    };
+    mockGetRun.mockResolvedValue(run);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("5.00 km")).toBeInTheDocument();
+    expect(screen.getByText("30:00")).toBeInTheDocument();
+    expect(screen.getByText("6:00 /km")).toBeInTheDocument();
+    expect(screen.getByText("420 kcal")).toBeInTheDocument();
+    expect(screen.getByText("85 m")).toBeInTheDocument();
+  });
+
+  it("shows Untitled Run when title is missing", async () => {
+    mockGetRun.mockResolvedValue({ ...baseRun, title: undefined });
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Untitled Run")).toBeInTheDocument();
+    });
+  });
+
+  it("shows notes section", async () => {
+    mockGetRun.mockResolvedValue({ ...baseRun, notes: "Felt great today!" });
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Felt great today!")).toBeInTheDocument();
+    });
+  });
+
+  it("hides notes section when no notes", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Notes")).not.toBeInTheDocument();
+  });
+
+  it("shows no route recorded placeholder", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("No route recorded")).toBeInTheDocument();
+    });
+  });
+});
 
 describe("RunDetailPage audio display", () => {
   it("shows spotify audio with artwork and Open in Spotify link", async () => {
@@ -122,7 +195,7 @@ describe("RunDetailPage audio display", () => {
       expect(screen.getByText("Morning Run")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Audio")).not.toBeInTheDocument();
+    expect(screen.queryByText("Music")).not.toBeInTheDocument();
   });
 
   it("shows spotify audio without artwork when imageUrl is null", async () => {
@@ -150,12 +223,233 @@ describe("RunDetailPage audio display", () => {
   });
 });
 
-describe("RunDetailPage edit — date preservation (regression #89)", () => {
-  beforeEach(() => {
-    mockGetRun.mockReset();
-    mockUpdateRun.mockReset();
+describe("RunDetailPage edit mode", () => {
+  it("enters edit mode and shows all fields", async () => {
+    const run: Run = {
+      ...baseRun,
+      notes: "Good run",
+      elevationGainMeters: 50,
+    };
+    mockGetRun.mockResolvedValue(run);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    expect(screen.getByLabelText("Title")).toHaveValue("Morning Run");
+    expect(screen.getByLabelText("Date")).toBeInTheDocument();
+    expect(screen.getByLabelText("Duration (HH:MM:SS)")).toHaveValue("00:30:00");
+    expect(screen.getByLabelText("Distance (km)")).toHaveValue(5);
+    expect(screen.getByLabelText("Elevation gain (m)")).toHaveValue(50);
+    expect(screen.getByLabelText("Notes")).toHaveValue("Good run");
   });
 
+  it("saves edited duration and distance", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+    mockUpdateRun.mockResolvedValue({
+      ...baseRun,
+      durationSeconds: 2400,
+      distanceMeters: 8000,
+    });
+
+    const user = userEvent.setup();
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    const durationInput = screen.getByLabelText("Duration (HH:MM:SS)");
+    await user.clear(durationInput);
+    await user.type(durationInput, "00:40:00");
+
+    const distanceInput = screen.getByLabelText("Distance (km)");
+    await user.clear(distanceInput);
+    await user.type(distanceInput, "8.00");
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-1", expect.objectContaining({
+        durationSeconds: 2400,
+        distanceMeters: 8000,
+      }));
+    });
+  });
+
+  it("shows validation error for invalid duration", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+
+    const user = userEvent.setup();
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    const durationInput = screen.getByLabelText("Duration (HH:MM:SS)");
+    await user.clear(durationInput);
+    await user.type(durationInput, "abc");
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid duration format. Use HH:MM:SS or MM:SS.")).toBeInTheDocument();
+    });
+
+    expect(mockUpdateRun).not.toHaveBeenCalled();
+  });
+
+  it("cancels edit mode and restores original values", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+
+    const user = userEvent.setup();
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    const titleInput = screen.getByLabelText("Title");
+    await user.clear(titleInput);
+    await user.type(titleInput, "Changed Title");
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Title")).not.toBeInTheDocument();
+  });
+});
+
+describe("RunDetailPage spotify editing", () => {
+  it("shows SpotifySearch in edit mode", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    expect(screen.getByText("Search Spotify")).toBeInTheDocument();
+    expect(screen.getByText("Enter manually")).toBeInTheDocument();
+  });
+
+  it("shows current spotify audio with remove button in edit mode", async () => {
+    const run: Run = {
+      ...baseRun,
+      audio: {
+        source: "spotify",
+        spotifyId: "track1",
+        type: "track",
+        name: "Levitating",
+        artistName: "Dua Lipa",
+        imageUrl: "https://i.scdn.co/image/img.jpg",
+        spotifyUrl: "https://open.spotify.com/track/track1",
+      },
+    };
+    mockGetRun.mockResolvedValue(run);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Levitating")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    // SpotifySearch chip shows the current audio with remove button
+    expect(screen.getByTestId("spotify-chip")).toBeInTheDocument();
+    expect(screen.getByText("Dua Lipa")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove audio")).toBeInTheDocument();
+  });
+
+  it("removes audio when Remove is clicked and saves with null", async () => {
+    const run: Run = {
+      ...baseRun,
+      audio: {
+        source: "spotify",
+        spotifyId: "track1",
+        type: "track",
+        name: "Levitating",
+        artistName: "Dua Lipa",
+        imageUrl: "https://i.scdn.co/image/img.jpg",
+        spotifyUrl: "https://open.spotify.com/track/track1",
+      },
+    };
+    mockGetRun.mockResolvedValue(run);
+    mockUpdateRun.mockResolvedValue({ ...baseRun, audio: undefined });
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Levitating")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.click(screen.getByLabelText("Remove audio"));
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockUpdateRun).toHaveBeenCalledWith("run-1", expect.objectContaining({
+        audio: null,
+      }));
+    });
+  });
+});
+
+describe("RunDetailPage delete", () => {
+  it("deletes run after confirmation and navigates home", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+    mockDeleteRun.mockResolvedValue(undefined);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Delete"));
+
+    await waitFor(() => {
+      expect(mockDeleteRun).toHaveBeenCalledWith("run-1");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
+  });
+
+  it("does not delete when confirmation is cancelled", async () => {
+    mockGetRun.mockResolvedValue(baseRun);
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Run")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Delete"));
+
+    expect(mockDeleteRun).not.toHaveBeenCalled();
+  });
+});
+
+describe("RunDetailPage edit — date preservation (regression #89)", () => {
   it("does not send runDate when date is unchanged", async () => {
     const run: Run = {
       ...baseRun,
@@ -183,10 +477,7 @@ describe("RunDetailPage edit — date preservation (regression #89)", () => {
     await user.click(screen.getByText("Save"));
 
     await waitFor(() => {
-      expect(mockUpdateRun).toHaveBeenCalledWith("run-1", {
-        title: "Evening Run",
-        notes: undefined,
-      });
+      expect(mockUpdateRun).toHaveBeenCalled();
     });
 
     // Verify runDate was NOT sent (preserves original)
@@ -214,9 +505,6 @@ describe("RunDetailPage edit — date preservation (regression #89)", () => {
     // Change the date
     const dateInput = screen.getByLabelText("Date");
     fireEvent.change(dateInput, { target: { value: "2026-03-25" } });
-
-    // Verify the input value actually changed
-    expect((dateInput as HTMLInputElement).value).toBe("2026-03-25");
 
     await user.click(screen.getByText("Save"));
 

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -1,11 +1,29 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { getRun, updateRun, deleteRun, completeRun } from "../api/client";
+import { getRun, updateRun, deleteRun } from "../api/client";
 import { RouteMap } from "../components/Map/RouteMap";
-import { formatDuration, formatPace, formatDate, formatCalories, formatAudio } from "../utils/format";
-import type { Run } from "../types/run";
+import { SpotifySearch } from "../components/Spotify/SpotifySearch";
+import { formatDuration, formatPace, formatDateTime, formatCalories, formatAudio } from "../utils/format";
+import type { Run, UpdateRunPayload } from "../types/run";
+import type { AudioRef } from "../types/audio";
 import shared from "../styles/shared.module.css";
 import styles from "../styles/RunDetailPage.module.css";
+
+function parseDuration(input: string): number | null {
+  const parts = input.split(":").map(Number);
+  if (parts.some(isNaN)) return null;
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  return null;
+}
+
+function formatDurationInput(seconds: number): string {
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(hrs)}:${pad(mins)}:${pad(secs)}`;
+}
 
 export function RunDetailPage() {
   const { runId } = useParams<{ runId: string }>();
@@ -19,10 +37,12 @@ export function RunDetailPage() {
   const [editNotes, setEditNotes] = useState("");
   const [editDate, setEditDate] = useState("");
   const [originalRunDate, setOriginalRunDate] = useState("");
+  const [editDuration, setEditDuration] = useState("");
+  const [editDistance, setEditDistance] = useState("");
+  const [editElevation, setEditElevation] = useState("");
+  const [editAudio, setEditAudio] = useState<AudioRef | undefined>(undefined);
+  const [audioRemoved, setAudioRemoved] = useState(false);
   const [saving, setSaving] = useState(false);
-
-  const [completing, setCompleting] = useState(false);
-  const [durationInput, setDurationInput] = useState("");
 
   useEffect(() => {
     if (!runId) return;
@@ -30,18 +50,43 @@ export function RunDetailPage() {
     getRun(runId)
       .then((data) => {
         setRun(data);
-        setEditTitle(data.title ?? "");
-        setEditNotes(data.notes ?? "");
-        setOriginalRunDate(data.runDate);
-        setEditDate(new Date(data.runDate).toLocaleDateString("sv-SE"));
+        populateEditFields(data);
       })
       .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false));
   }, [runId]);
 
+  function populateEditFields(data: Run) {
+    setEditTitle(data.title ?? "");
+    setEditNotes(data.notes ?? "");
+    setOriginalRunDate(data.runDate);
+    setEditDate(new Date(data.runDate).toLocaleDateString("sv-SE"));
+    setEditDuration(data.durationSeconds ? formatDurationInput(data.durationSeconds) : "");
+    setEditDistance(data.distanceMeters ? (data.distanceMeters / 1000).toFixed(2) : "");
+    setEditElevation(data.elevationGainMeters !== undefined ? String(data.elevationGainMeters) : "");
+    setEditAudio(data.audio);
+    setAudioRemoved(false);
+  }
+
+  function startEditing() {
+    if (run) populateEditFields(run);
+    setEditing(true);
+  }
+
+  function cancelEditing() {
+    if (run) populateEditFields(run);
+    setEditing(false);
+  }
+
+  function handleAudioChange(audio: AudioRef | undefined) {
+    setEditAudio(audio);
+    setAudioRemoved(!audio);
+  }
+
   async function handleSaveEdit() {
     if (!runId) return;
     setSaving(true);
+    setError(null);
     try {
       // Only send runDate if the user actually changed the date
       let runDate: string | undefined;
@@ -55,11 +100,49 @@ export function RunDetailPage() {
         runDate = updated.toISOString();
       }
 
-      const updated = await updateRun(runId, {
+      const payload: UpdateRunPayload = {
         title: editTitle.trim() || undefined,
         notes: editNotes.trim() || undefined,
         ...(runDate !== undefined ? { runDate } : {}),
-      });
+      };
+
+      if (editDuration.trim()) {
+        const seconds = parseDuration(editDuration);
+        if (seconds === null || seconds <= 0) {
+          setError("Invalid duration format. Use HH:MM:SS or MM:SS.");
+          setSaving(false);
+          return;
+        }
+        payload.durationSeconds = seconds;
+      }
+
+      if (editDistance.trim()) {
+        const km = parseFloat(editDistance);
+        if (isNaN(km) || km < 0) {
+          setError("Invalid distance.");
+          setSaving(false);
+          return;
+        }
+        payload.distanceMeters = Math.round(km * 1000);
+      }
+
+      if (editElevation.trim()) {
+        const elev = parseFloat(editElevation);
+        if (isNaN(elev) || elev < 0) {
+          setError("Invalid elevation.");
+          setSaving(false);
+          return;
+        }
+        payload.elevationGainMeters = Math.round(elev);
+      }
+
+      if (audioRemoved) {
+        payload.audio = null;
+      } else if (editAudio) {
+        payload.audio = editAudio;
+      }
+
+      const updated = await updateRun(runId, payload);
       setRun(updated);
       setOriginalRunDate(updated.runDate);
       setEditing(false);
@@ -79,32 +162,6 @@ export function RunDetailPage() {
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to delete";
       setError(message);
-    }
-  }
-
-  function parseDuration(input: string): number | null {
-    const parts = input.split(":").map(Number);
-    if (parts.some(isNaN)) return null;
-    if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
-    if (parts.length === 2) return parts[0] * 60 + parts[1];
-    return null;
-  }
-
-  async function handleComplete() {
-    if (!runId) return;
-    const seconds = parseDuration(durationInput);
-    if (!seconds || seconds <= 0) return;
-    setSaving(true);
-    try {
-      const updated = await completeRun(runId, { durationSeconds: seconds });
-      setRun(updated);
-      setCompleting(false);
-      setDurationInput("");
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to complete run";
-      setError(message);
-    } finally {
-      setSaving(false);
     }
   }
 
@@ -160,6 +217,43 @@ export function RunDetailPage() {
               />
             </div>
             <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="editDuration">Duration (HH:MM:SS)</label>
+              <input
+                id="editDuration"
+                className={shared.formInput}
+                type="text"
+                placeholder="00:32:15"
+                value={editDuration}
+                onChange={(e) => setEditDuration(e.target.value)}
+              />
+            </div>
+            <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="editDistance">Distance (km)</label>
+              <input
+                id="editDistance"
+                className={shared.formInput}
+                type="number"
+                step="0.01"
+                min="0"
+                placeholder="5.00"
+                value={editDistance}
+                onChange={(e) => setEditDistance(e.target.value)}
+              />
+            </div>
+            <div className={shared.formGroup}>
+              <label className={shared.formLabel} htmlFor="editElevation">Elevation gain (m)</label>
+              <input
+                id="editElevation"
+                className={shared.formInput}
+                type="number"
+                step="1"
+                min="0"
+                placeholder="120"
+                value={editElevation}
+                onChange={(e) => setEditElevation(e.target.value)}
+              />
+            </div>
+            <div className={shared.formGroup}>
               <label className={shared.formLabel} htmlFor="editNotes">Notes</label>
               <textarea
                 id="editNotes"
@@ -168,11 +262,17 @@ export function RunDetailPage() {
                 onChange={(e) => setEditNotes(e.target.value)}
               />
             </div>
+
+            <div className={styles.audioSection}>
+              <label className={shared.formLabel}>Music</label>
+              <SpotifySearch value={editAudio} onChange={handleAudioChange} />
+            </div>
+
             <div className={styles.actions}>
               <button className={shared.buttonPrimary} onClick={handleSaveEdit} disabled={saving}>
                 {saving ? "Saving..." : "Save"}
               </button>
-              <button className={shared.buttonSecondary} onClick={() => setEditing(false)}>
+              <button className={shared.buttonSecondary} onClick={cancelEditing}>
                 Cancel
               </button>
             </div>
@@ -180,7 +280,7 @@ export function RunDetailPage() {
         ) : (
           <>
             <h1 className={styles.runTitle}>{run.title || "Untitled Run"}</h1>
-            <div className={styles.runDate}>{formatDate(run.runDate)}</div>
+            <div className={styles.runDate}>{formatDateTime(run.runDate)}</div>
 
             <div className={styles.statsGrid}>
               {run.distanceMeters !== undefined && (
@@ -227,21 +327,22 @@ export function RunDetailPage() {
 
             {run.audio && run.audio.source === "spotify" && (
               <div className={styles.section}>
-                <div className={styles.sectionLabel}>Audio</div>
-                <div className={styles.audioDisplay}>
+                <div className={styles.sectionLabel}>Music</div>
+                <div className={styles.spotifyCard}>
                   {run.audio.imageUrl?.startsWith("https://i.scdn.co/") && (
                     <img
-                      className={styles.audioArtwork}
+                      className={styles.spotifyArt}
                       src={run.audio.imageUrl}
                       alt={run.audio.name}
-                      width={200}
-                      height={200}
                     />
                   )}
-                  <div>
-                    <div className={styles.sectionValue}>{run.audio.name}</div>
+                  <div className={styles.spotifyInfo}>
+                    <div className={styles.spotifyTrack}>{run.audio.name}</div>
                     {run.audio.artistName && (
-                      <div className={styles.audioArtist}>{run.audio.artistName}</div>
+                      <div className={styles.spotifyArtist}>{run.audio.artistName}</div>
+                    )}
+                    {run.audio.albumName && (
+                      <div className={styles.spotifyAlbum}>{run.audio.albumName}</div>
                     )}
                     {run.audio.spotifyUrl?.startsWith("https://open.spotify.com/") && (
                       <a
@@ -260,7 +361,7 @@ export function RunDetailPage() {
 
             {run.audio && run.audio.source === "manual" && (
               <div className={styles.section}>
-                <div className={styles.sectionLabel}>Audio</div>
+                <div className={styles.sectionLabel}>Music</div>
                 <div className={styles.sectionValue}>
                   {formatAudio(run.audio)}
                 </div>
@@ -270,49 +371,18 @@ export function RunDetailPage() {
             {run.notes && (
               <div className={styles.section}>
                 <div className={styles.sectionLabel}>Notes</div>
-                <div className={styles.sectionValue}>{run.notes}</div>
+                <div className={styles.notesText}>{run.notes}</div>
               </div>
             )}
 
             <div className={styles.actions}>
-              <button className={shared.buttonSecondary} onClick={() => setEditing(true)}>
+              <button className={shared.buttonSecondary} onClick={startEditing}>
                 Edit
               </button>
-              {run.status === "planned" && !completing && (
-                <button className={shared.buttonPrimary} onClick={() => setCompleting(true)}>
-                  Complete Run
-                </button>
-              )}
               <button className={shared.buttonDanger} onClick={handleDelete}>
                 Delete
               </button>
             </div>
-
-            {completing && (
-              <div className={styles.editForm}>
-                <div className={shared.formGroup}>
-                  <label className={shared.formLabel} htmlFor="completeDuration">
-                    Duration (HH:MM:SS or MM:SS)
-                  </label>
-                  <input
-                    id="completeDuration"
-                    className={shared.formInput}
-                    type="text"
-                    placeholder="32:15"
-                    value={durationInput}
-                    onChange={(e) => setDurationInput(e.target.value)}
-                  />
-                </div>
-                <div className={styles.actions}>
-                  <button className={shared.buttonPrimary} onClick={handleComplete} disabled={saving}>
-                    {saving ? "Completing..." : "Submit"}
-                  </button>
-                  <button className={shared.buttonSecondary} onClick={() => setCompleting(false)}>
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            )}
           </>
         )}
       </div>

--- a/frontend/src/styles/RunDetailPage.module.css
+++ b/frontend/src/styles/RunDetailPage.module.css
@@ -26,6 +26,15 @@
   margin-top: -16px;
   position: relative;
   padding: 1.25rem 1rem 2rem;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (min-width: 769px) {
+  .detailCard {
+    padding: 1.5rem 2rem 2.5rem;
+  }
 }
 
 .runTitle {
@@ -46,6 +55,12 @@
   grid-template-columns: 1fr 1fr;
   gap: 0.75rem;
   margin-top: 1rem;
+}
+
+@media (min-width: 769px) {
+  .statsGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .statItem {
@@ -69,7 +84,7 @@
 }
 
 .section {
-  margin-top: 1rem;
+  margin-top: 1.25rem;
 }
 
 .sectionLabel {
@@ -86,35 +101,56 @@
   margin-top: 0.25rem;
 }
 
-.actions {
-  display: flex;
-  gap: 0.5rem;
-  margin-top: 1.5rem;
-}
-
-.editForm {
-  margin-top: 1rem;
-}
-
-.audioDisplay {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
+.notesText {
+  font-size: 1rem;
+  color: #333;
   margin-top: 0.25rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
 }
 
-.audioArtwork {
-  max-width: 200px;
-  aspect-ratio: 1;
-  max-height: 200px;
-  border-radius: 4px;
+/* Spotify card — mini player style */
+.spotifyCard {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  background: #f9f9f9;
+  border-radius: 10px;
+  padding: 0.75rem;
+}
+
+.spotifyArt {
+  width: 64px;
+  height: 64px;
+  border-radius: 6px;
   object-fit: cover;
+  flex-shrink: 0;
 }
 
-.audioArtist {
-  font-size: 0.875rem;
+.spotifyInfo {
+  min-width: 0;
+}
+
+.spotifyTrack {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spotifyArtist {
+  font-size: 0.8125rem;
   color: #666;
   margin-top: 0.125rem;
+}
+
+.spotifyAlbum {
+  font-size: 0.75rem;
+  color: #999;
+  margin-top: 0.0625rem;
 }
 
 .spotifyLink {
@@ -128,4 +164,64 @@
 
 .spotifyLink:hover {
   text-decoration: underline;
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+/* Edit form */
+.editForm {
+  margin-top: 0.5rem;
+}
+
+/* Audio section in edit mode */
+.audioSection {
+  background: #f9f9f9;
+  border-radius: 10px;
+  padding: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.audioEditCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e8e8e8;
+}
+
+.audioEditInfo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.audioEditThumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.audioEditName {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.audioEditArtist {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.audioEditActions {
+  flex-shrink: 0;
 }

--- a/frontend/src/types/run.ts
+++ b/frontend/src/types/run.ts
@@ -39,7 +39,7 @@ export interface UpdateRunPayload {
   distanceMeters?: number;
   durationSeconds?: number;
   elevationGainMeters?: number;
-  audio?: AudioRef;
+  audio?: AudioRef | null;
 }
 
 export interface CompleteRunPayload {


### PR DESCRIPTION
Implements feature #84.

## Changes

### Run Detail View
- Hero map full-width at top
- Rich stats cards: distance, duration, pace, calories, elevation
- Date/time display in browser-local timezone
- Notes section
- Spotify song card with album art, artist, track, open in Spotify link

### Run Editing
- Edit all fields: title, date, duration (HH:MM:SS), distance (km), elevation
- Spotify song editing: change/remove music via SpotifySearch component
- Save/cancel with validation
- Optimistic UI updates

### Spotify Display
- Mini player-style card with album art
- Artist name, track name, album
- Link to open in Spotify
- Change music / Remove buttons in edit mode

### Tests
- View mode: all stat display variants, audio display, no audio
- Edit mode: field population, save with duration/distance/audio, cancel
- Spotify editing: chip display, remove audio, change via search

Closes #84