### PR TITLE
fix: Allow App bot in claude-code-action + remove invalid input

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -48,4 +48,4 @@ jobs:
           claude_args: "--model sonnet --max-turns 30"
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude"
-          timeout_minutes: 15
+          allowed_bots: "runmaprepeat-autofix[bot],github-actions[bot]"


### PR DESCRIPTION
## Problem

Auto-fix cycle 2 on PR #91 failed with:
```
Workflow initiated by non-human actor: runmaprepeat-autofix (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Cycle 1 worked because it was triggered by `github-actions[bot]` (from the review workflow). But cycle 2's `@claude` comment was posted by `runmaprepeat-autofix[bot]` (the GitHub App), which wasn't allowlisted.

## Fix
- Add `allowed_bots: runmaprepeat-autofix[bot],github-actions[bot]`
- Remove invalid `timeout_minutes` input (was causing warnings)

Refs: #90