### PR TITLE
feat: Multi-select Spotify search — artist + album/playlist

### DIFF
--- a/backend/handlers/utils/validation.py
+++ b/backend/handlers/utils/validation.py
@@ -88,7 +88,13 @@ def validate_run(body: dict[str, Any]) -> list[str]:
             errors.append("elevationGainMeters must be a non-negative number")
 
     if "audio" in body:
-        errors.extend(validate_audio(body["audio"]))
+        audio = body["audio"]
+        if isinstance(audio, list):
+            for i, item in enumerate(audio):
+                item_errors = validate_audio(item)
+                errors.extend(f"audio[{i}].{e.split('.', 1)[1]}" if '.' in e else e for e in item_errors)
+        else:
+            errors.extend(validate_audio(audio))
 
     return errors
 

--- a/backend/tests/test_spotify_search.py
+++ b/backend/tests/test_spotify_search.py
@@ -513,3 +513,58 @@ def test_validate_audio_invalid_artist_name_type() -> None:
     }
     errors = validate_audio(audio)
     assert any("artistName" in e for e in errors)
+
+
+# --- validate_run audio array tests ---
+
+from handlers.utils.validation import validate_run
+
+
+def test_validate_run_audio_array_valid() -> None:
+    body = {
+        "audio": [
+            {
+                "source": "spotify",
+                "spotifyId": "abc",
+                "type": "artist",
+                "name": "Daft Punk",
+                "spotifyUrl": "https://open.spotify.com/artist/abc",
+            },
+            {
+                "source": "spotify",
+                "spotifyId": "def",
+                "type": "album",
+                "name": "RAM",
+                "spotifyUrl": "https://open.spotify.com/album/def",
+            },
+        ]
+    }
+    assert validate_run(body) == []
+
+
+def test_validate_run_audio_array_with_invalid_item() -> None:
+    body = {
+        "audio": [
+            {
+                "source": "spotify",
+                "spotifyId": "abc",
+                "type": "artist",
+                "name": "Daft Punk",
+                "spotifyUrl": "https://open.spotify.com/artist/abc",
+            },
+            {"source": "spotify", "name": "Missing fields"},
+        ]
+    }
+    errors = validate_run(body)
+    assert len(errors) > 0
+    assert any("audio[1]" in e for e in errors)
+
+
+def test_validate_run_audio_single_object_still_works() -> None:
+    body = {
+        "audio": {
+            "source": "manual",
+            "name": "My Playlist",
+        }
+    }
+    assert validate_run(body) == []

--- a/frontend/src/__tests__/NewRunPage.test.tsx
+++ b/frontend/src/__tests__/NewRunPage.test.tsx
@@ -222,7 +222,7 @@ describe("NewRunPage Spotify integration", () => {
 
     const callArg = mockCreateRun.mock.calls[0][0];
     expect(callArg).toHaveProperty("audio");
-    expect(callArg.audio).toEqual(sampleSpotifyResults[0]);
+    expect(callArg.audio).toEqual([sampleSpotifyResults[0]]);
   });
 
   it("remove button clears Spotify selection", async () => {
@@ -240,7 +240,7 @@ describe("NewRunPage Spotify integration", () => {
     });
 
     // Click remove button
-    fireEvent.click(screen.getByLabelText("Remove audio"));
+    fireEvent.click(screen.getByLabelText("Remove Daft Punk"));
 
     // Chip should be gone, search input should be back
     expect(screen.queryByTestId("spotify-chip")).not.toBeInTheDocument();
@@ -284,10 +284,10 @@ describe("NewRunPage Spotify integration", () => {
 
     const callArg = mockCreateRun.mock.calls[0][0];
     expect(callArg).toHaveProperty("audio");
-    expect(callArg.audio).toEqual({
+    expect(callArg.audio).toEqual([{
       source: "manual",
       name: "My Running Playlist",
       artistName: "Various Artists",
-    });
+    }]);
   });
 });

--- a/frontend/src/__tests__/RunDetailPage.test.tsx
+++ b/frontend/src/__tests__/RunDetailPage.test.tsx
@@ -135,7 +135,7 @@ describe("RunDetailPage view mode", () => {
 });
 
 describe("RunDetailPage audio display", () => {
-  it("shows spotify audio with artwork and Open in Spotify link", async () => {
+  it("shows spotify audio with artwork and Open in Spotify link (legacy single)", async () => {
     const run: Run = {
       ...baseRun,
       audio: {
@@ -164,6 +164,41 @@ describe("RunDetailPage audio display", () => {
 
     const artwork = screen.getByAltText("Levitating");
     expect(artwork).toHaveAttribute("src", "https://i.scdn.co/image/img.jpg");
+  });
+
+  it("shows multiple spotify audio items (array format)", async () => {
+    const run: Run = {
+      ...baseRun,
+      audio: [
+        {
+          source: "spotify",
+          spotifyId: "artist1",
+          type: "artist",
+          name: "Dua Lipa",
+          imageUrl: "https://i.scdn.co/image/dua.jpg",
+          spotifyUrl: "https://open.spotify.com/artist/artist1",
+        },
+        {
+          source: "spotify",
+          spotifyId: "album1",
+          type: "album",
+          name: "Future Nostalgia",
+          artistName: "Dua Lipa",
+          imageUrl: "https://i.scdn.co/image/fn.jpg",
+          spotifyUrl: "https://open.spotify.com/album/album1",
+        },
+      ],
+    };
+    mockGetRun.mockResolvedValue(run);
+
+    renderRunDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Future Nostalgia")).toBeInTheDocument();
+    });
+
+    const links = screen.getAllByText("Open in Spotify");
+    expect(links).toHaveLength(2);
   });
 
   it("shows manual audio as plain text", async () => {
@@ -373,7 +408,7 @@ describe("RunDetailPage spotify editing", () => {
     // SpotifySearch chip shows the current audio with remove button
     expect(screen.getByTestId("spotify-chip")).toBeInTheDocument();
     expect(screen.getByText("Dua Lipa")).toBeInTheDocument();
-    expect(screen.getByLabelText("Remove audio")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove Levitating")).toBeInTheDocument();
   });
 
   it("removes audio when Remove is clicked and saves with null", async () => {
@@ -399,7 +434,7 @@ describe("RunDetailPage spotify editing", () => {
     });
 
     fireEvent.click(screen.getByText("Edit"));
-    fireEvent.click(screen.getByLabelText("Remove audio"));
+    fireEvent.click(screen.getByLabelText("Remove Levitating"));
     fireEvent.click(screen.getByText("Save"));
 
     await waitFor(() => {

--- a/frontend/src/__tests__/SpotifySearch.test.tsx
+++ b/frontend/src/__tests__/SpotifySearch.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { SpotifySearch } from "../components/Spotify/SpotifySearch";
-import type { SpotifyRef } from "../types/audio";
+import type { SpotifyRef, AudioRef } from "../types/audio";
+import { normalizeAudio, MAX_AUDIO_SELECTIONS } from "../types/audio";
 
 const mockSearchSpotify = vi.fn();
 
@@ -57,7 +58,7 @@ async function typeAndSearch(query: string) {
 
 describe("SpotifySearch", () => {
   it("renders search input and tab toggle", () => {
-    render(<SpotifySearch value={undefined} onChange={vi.fn()} />);
+    render(<SpotifySearch value={[]} onChange={vi.fn()} />);
     expect(screen.getByLabelText("Search Spotify")).toBeInTheDocument();
     expect(screen.getByText("Search Spotify")).toBeInTheDocument();
     expect(screen.getByText("Enter manually")).toBeInTheDocument();
@@ -66,7 +67,7 @@ describe("SpotifySearch", () => {
   it("debounces search input by 300ms", async () => {
     mockSearchSpotify.mockResolvedValue({ artists: [], albums: [], tracks: [] });
     vi.useFakeTimers();
-    render(<SpotifySearch value={undefined} onChange={vi.fn()} />);
+    render(<SpotifySearch value={[]} onChange={vi.fn()} />);
 
     const input = screen.getByLabelText("Search Spotify");
     fireEvent.change(input, { target: { value: "Dua" } });
@@ -87,7 +88,7 @@ describe("SpotifySearch", () => {
       tracks: [sampleResults[2]],
     });
 
-    render(<SpotifySearch value={undefined} onChange={vi.fn()} />);
+    render(<SpotifySearch value={[]} onChange={vi.fn()} />);
     await typeAndSearch("Dua Lipa");
 
     await waitFor(() => {
@@ -96,12 +97,11 @@ describe("SpotifySearch", () => {
       expect(screen.getByText("Levitating")).toBeInTheDocument();
     });
 
-    // "Dua Lipa" appears multiple times (artist name + subtexts), verify all present
     const duaElements = screen.getAllByText("Dua Lipa");
     expect(duaElements.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("calls onChange when result is clicked", async () => {
+  it("calls onChange with array when result is clicked", async () => {
     mockSearchSpotify.mockResolvedValue({
       artists: [sampleResults[0]],
       albums: [],
@@ -109,33 +109,35 @@ describe("SpotifySearch", () => {
     });
     const onChange = vi.fn();
 
-    render(<SpotifySearch value={undefined} onChange={onChange} />);
+    render(<SpotifySearch value={[]} onChange={onChange} />);
     await typeAndSearch("Dua");
 
     await waitFor(() => {
       expect(screen.getByTestId("spotify-dropdown")).toBeInTheDocument();
     });
 
-    // Click the result item button containing "Dua Lipa"
     const options = screen.getAllByRole("option");
     fireEvent.click(options[0]);
-    expect(onChange).toHaveBeenCalledWith(sampleResults[0]);
+    expect(onChange).toHaveBeenCalledWith([sampleResults[0]]);
   });
 
   it("shows chip when spotify value is selected", () => {
-    render(<SpotifySearch value={sampleResults[0]} onChange={vi.fn()} />);
+    render(<SpotifySearch value={[sampleResults[0]]} onChange={vi.fn()} />);
     expect(screen.getByTestId("spotify-chip")).toBeInTheDocument();
-    // The chip should show the name
     const chip = screen.getByTestId("spotify-chip");
     expect(chip.textContent).toContain("Dua Lipa");
   });
 
-  it("removes selection when chip x is clicked", () => {
+  it("removes specific selection when chip x is clicked", () => {
     const onChange = vi.fn();
-    render(<SpotifySearch value={sampleResults[0]} onChange={onChange} />);
+    render(<SpotifySearch value={[sampleResults[0], sampleResults[1]]} onChange={onChange} />);
 
-    fireEvent.click(screen.getByLabelText("Remove audio"));
-    expect(onChange).toHaveBeenCalledWith(undefined);
+    const chips = screen.getAllByTestId("spotify-chip");
+    expect(chips).toHaveLength(2);
+
+    // Remove first chip
+    fireEvent.click(screen.getByLabelText("Remove Dua Lipa"));
+    expect(onChange).toHaveBeenCalledWith([sampleResults[1]]);
   });
 
   it("supports keyboard navigation", async () => {
@@ -146,7 +148,7 @@ describe("SpotifySearch", () => {
     });
     const onChange = vi.fn();
 
-    render(<SpotifySearch value={undefined} onChange={onChange} />);
+    render(<SpotifySearch value={[]} onChange={onChange} />);
     await typeAndSearch("Dua");
 
     await waitFor(() => {
@@ -158,7 +160,7 @@ describe("SpotifySearch", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(onChange).toHaveBeenCalledWith(sampleResults[1]);
+    expect(onChange).toHaveBeenCalledWith([sampleResults[1]]);
   });
 
   it("closes dropdown on Escape", async () => {
@@ -168,7 +170,7 @@ describe("SpotifySearch", () => {
       tracks: [],
     });
 
-    render(<SpotifySearch value={undefined} onChange={vi.fn()} />);
+    render(<SpotifySearch value={[]} onChange={vi.fn()} />);
     await typeAndSearch("Dua");
 
     await waitFor(() => {
@@ -183,7 +185,7 @@ describe("SpotifySearch", () => {
   it("shows no results message when search returns empty", async () => {
     mockSearchSpotify.mockResolvedValue({ artists: [], albums: [], tracks: [] });
 
-    render(<SpotifySearch value={undefined} onChange={vi.fn()} />);
+    render(<SpotifySearch value={[]} onChange={vi.fn()} />);
     await typeAndSearch("xyznonexistent");
 
     await waitFor(() => {
@@ -193,45 +195,185 @@ describe("SpotifySearch", () => {
 
   it("switches to manual mode", () => {
     const onChange = vi.fn();
-    render(<SpotifySearch value={undefined} onChange={onChange} />);
+    render(<SpotifySearch value={[]} onChange={onChange} />);
 
     fireEvent.click(screen.getByText("Enter manually"));
     expect(screen.getByLabelText("Audio name")).toBeInTheDocument();
     expect(screen.getByLabelText("Artist name")).toBeInTheDocument();
   });
 
-  it("manual mode calls onChange with manual ref", () => {
+  it("manual mode calls onChange with array containing manual ref", () => {
     const onChange = vi.fn();
-    render(<SpotifySearch value={undefined} onChange={onChange} />);
+    render(<SpotifySearch value={[]} onChange={onChange} />);
 
     fireEvent.click(screen.getByText("Enter manually"));
 
     fireEvent.change(screen.getByLabelText("Audio name"), {
       target: { value: "My Podcast" },
     });
-    expect(onChange).toHaveBeenCalledWith({
+    expect(onChange).toHaveBeenCalledWith([{
       source: "manual",
       name: "My Podcast",
-    });
+    }]);
 
     fireEvent.change(screen.getByLabelText("Artist name"), {
       target: { value: "Host Name" },
     });
-    expect(onChange).toHaveBeenCalledWith({
+    expect(onChange).toHaveBeenCalledWith([{
       source: "manual",
       name: "My Podcast",
       artistName: "Host Name",
-    });
+    }]);
   });
 
   it("falls back to manual mode on API error", async () => {
     mockSearchSpotify.mockRejectedValue(new Error("API error"));
 
-    render(<SpotifySearch value={undefined} onChange={vi.fn()} />);
+    render(<SpotifySearch value={[]} onChange={vi.fn()} />);
     await typeAndSearch("test");
 
     await waitFor(() => {
       expect(screen.getByLabelText("Audio name")).toBeInTheDocument();
     });
+  });
+});
+
+describe("SpotifySearch multi-select", () => {
+  it("keeps search open after selecting one item", async () => {
+    mockSearchSpotify.mockResolvedValue({
+      artists: [sampleResults[0]],
+      albums: [sampleResults[1]],
+      tracks: [],
+    });
+    const onChange = vi.fn();
+
+    render(<SpotifySearch value={[]} onChange={onChange} />);
+    await typeAndSearch("Dua");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spotify-dropdown")).toBeInTheDocument();
+    });
+
+    const options = screen.getAllByRole("option");
+    fireEvent.click(options[0]);
+
+    // onChange called with first item — search input should still be available
+    // (parent re-renders with updated value)
+    expect(onChange).toHaveBeenCalledWith([sampleResults[0]]);
+  });
+
+  it("shows multiple chips for multiple selections", () => {
+    render(
+      <SpotifySearch
+        value={[sampleResults[0], sampleResults[1]]}
+        onChange={vi.fn()}
+      />
+    );
+
+    const chips = screen.getAllByTestId("spotify-chip");
+    expect(chips).toHaveLength(2);
+    expect(chips[0].textContent).toContain("Dua Lipa");
+    expect(chips[1].textContent).toContain("Future Nostalgia");
+  });
+
+  it("shows max message when 3 items selected", () => {
+    render(
+      <SpotifySearch
+        value={[sampleResults[0], sampleResults[1], sampleResults[2]]}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(`Maximum of ${MAX_AUDIO_SELECTIONS} selections reached`)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Search Spotify")).not.toBeInTheDocument();
+  });
+
+  it("does not allow selecting duplicate items", async () => {
+    mockSearchSpotify.mockResolvedValue({
+      artists: [sampleResults[0]],
+      albums: [],
+      tracks: [],
+    });
+    const onChange = vi.fn();
+
+    render(
+      <SpotifySearch
+        value={[sampleResults[0]]}
+        onChange={onChange}
+      />
+    );
+    await typeAndSearch("Dua");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spotify-dropdown")).toBeInTheDocument();
+    });
+
+    // The already-selected item should be disabled
+    const options = screen.getAllByRole("option");
+    expect(options[0]).toBeDisabled();
+    fireEvent.click(options[0]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("appends to existing selections when selecting a new item", async () => {
+    mockSearchSpotify.mockResolvedValue({
+      artists: [],
+      albums: [sampleResults[1]],
+      tracks: [],
+    });
+    const onChange = vi.fn();
+
+    render(
+      <SpotifySearch
+        value={[sampleResults[0]]}
+        onChange={onChange}
+      />
+    );
+    await typeAndSearch("Future");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spotify-dropdown")).toBeInTheDocument();
+    });
+
+    const options = screen.getAllByRole("option");
+    fireEvent.click(options[0]);
+    expect(onChange).toHaveBeenCalledWith([sampleResults[0], sampleResults[1]]);
+  });
+
+  it("shows updated placeholder text when items are selected", () => {
+    render(
+      <SpotifySearch
+        value={[sampleResults[0]]}
+        onChange={vi.fn()}
+      />
+    );
+
+    const input = screen.getByLabelText("Search Spotify");
+    expect(input).toHaveAttribute("placeholder", "Add another (1/3)...");
+  });
+});
+
+describe("normalizeAudio", () => {
+  it("returns empty array for undefined", () => {
+    expect(normalizeAudio(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for null", () => {
+    expect(normalizeAudio(null)).toEqual([]);
+  });
+
+  it("wraps single AudioRef in array", () => {
+    const single: AudioRef = sampleResults[0];
+    expect(normalizeAudio(single)).toEqual([single]);
+  });
+
+  it("returns array as-is", () => {
+    const arr: AudioRef[] = [sampleResults[0], sampleResults[1]];
+    expect(normalizeAudio(arr)).toBe(arr);
+  });
+
+  it("wraps manual ref in array", () => {
+    const manual: AudioRef = { source: "manual", name: "Test" };
+    expect(normalizeAudio(manual)).toEqual([manual]);
   });
 });

--- a/frontend/src/components/Spotify/SpotifySearch.module.css
+++ b/frontend/src/components/Spotify/SpotifySearch.module.css
@@ -147,6 +147,20 @@
   flex-shrink: 0;
 }
 
+.chipList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
+}
+
+.maxMessage {
+  font-size: 0.8125rem;
+  color: #888;
+  text-align: center;
+  padding: 0.5rem;
+}
+
 .chip {
   display: flex;
   align-items: center;

--- a/frontend/src/components/Spotify/SpotifySearch.tsx
+++ b/frontend/src/components/Spotify/SpotifySearch.tsx
@@ -2,19 +2,20 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { searchSpotify } from "../../api/client";
 import type { SpotifySearchResult } from "../../api/client";
 import type { AudioRef, SpotifyRef } from "../../types/audio";
+import { MAX_AUDIO_SELECTIONS } from "../../types/audio";
 import styles from "./SpotifySearch.module.css";
 
 const DEBOUNCE_MS = 300;
 const isValidSpotifyImage = (url: string) => url.startsWith("https://i.scdn.co/");
 
 interface SpotifySearchProps {
-  value: AudioRef | undefined;
-  onChange: (audio: AudioRef | undefined) => void;
+  value: AudioRef[];
+  onChange: (audio: AudioRef[]) => void;
 }
 
 export function SpotifySearch({ value, onChange }: SpotifySearchProps) {
   const [mode, setMode] = useState<"spotify" | "manual">(
-    value?.source === "manual" ? "manual" : "spotify"
+    value.length === 1 && value[0].source === "manual" ? "manual" : "spotify"
   );
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SpotifyRef[]>([]);
@@ -23,15 +24,15 @@ export function SpotifySearch({ value, onChange }: SpotifySearchProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
   const [searched, setSearched] = useState(false);
 
-  const [manualName, setManualName] = useState(
-    value?.source === "manual" ? value.name : ""
-  );
-  const [manualArtist, setManualArtist] = useState(
-    value?.source === "manual" ? (value.artistName ?? "") : ""
-  );
+  const manualItem = value.length === 1 && value[0].source === "manual" ? value[0] : undefined;
+  const [manualName, setManualName] = useState(manualItem?.name ?? "");
+  const [manualArtist, setManualArtist] = useState(manualItem?.artistName ?? "");
 
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const spotifyItems = value.filter((v): v is SpotifyRef => v.source === "spotify");
+  const atMax = spotifyItems.length >= MAX_AUDIO_SELECTIONS;
 
   const flattenResults = useCallback((data: SpotifySearchResult): SpotifyRef[] => {
     const flat: SpotifyRef[] = [];
@@ -67,7 +68,6 @@ export function SpotifySearch({ value, onChange }: SpotifySearchProps) {
           setResults([]);
           setShowDropdown(false);
           setSearched(true);
-          // Silent fallback — switch to manual on API error
           setMode("manual");
         })
         .finally(() => {
@@ -90,15 +90,27 @@ export function SpotifySearch({ value, onChange }: SpotifySearchProps) {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  function isAlreadySelected(item: SpotifyRef): boolean {
+    return spotifyItems.some(
+      (s) => s.spotifyId === item.spotifyId && s.type === item.type
+    );
+  }
+
   function handleSelect(item: SpotifyRef) {
-    onChange({ ...item, source: "spotify" });
+    if (isAlreadySelected(item) || atMax) return;
+    onChange([...value, { ...item, source: "spotify" }]);
     setQuery("");
     setShowDropdown(false);
     setResults([]);
   }
 
-  function handleRemove() {
-    onChange(undefined);
+  function handleRemove(index: number) {
+    const next = value.filter((_, i) => i !== index);
+    onChange(next);
+  }
+
+  function handleRemoveAll() {
+    onChange([]);
     setQuery("");
     setManualName("");
     setManualArtist("");
@@ -123,56 +135,25 @@ export function SpotifySearch({ value, onChange }: SpotifySearchProps) {
   function handleManualNameChange(name: string) {
     setManualName(name);
     if (name.trim()) {
-      onChange({
+      onChange([{
         source: "manual",
         name: name.trim(),
         ...(manualArtist.trim() ? { artistName: manualArtist.trim() } : {}),
-      });
+      }]);
     } else {
-      onChange(undefined);
+      onChange([]);
     }
   }
 
   function handleManualArtistChange(artist: string) {
     setManualArtist(artist);
     if (manualName.trim()) {
-      onChange({
+      onChange([{
         source: "manual",
         name: manualName.trim(),
         ...(artist.trim() ? { artistName: artist.trim() } : {}),
-      });
+      }]);
     }
-  }
-
-  // If a spotify value is selected, show chip
-  if (value && value.source === "spotify" && mode === "spotify") {
-    return (
-      <div className={styles.container}>
-        <div className={styles.chip} data-testid="spotify-chip">
-          {value.imageUrl && isValidSpotifyImage(value.imageUrl) && (
-            <img
-              className={styles.chipImage}
-              src={value.imageUrl}
-              alt={value.name}
-            />
-          )}
-          <div className={styles.chipInfo}>
-            <div className={styles.chipName}>{value.name}</div>
-            {value.artistName && (
-              <div className={styles.chipSubtext}>{value.artistName}</div>
-            )}
-          </div>
-          <button
-            type="button"
-            className={styles.chipRemove}
-            onClick={handleRemove}
-            aria-label="Remove audio"
-          >
-            x
-          </button>
-        </div>
-      </div>
-    );
   }
 
   return (
@@ -181,14 +162,14 @@ export function SpotifySearch({ value, onChange }: SpotifySearchProps) {
         <button
           type="button"
           className={mode === "spotify" ? styles.tabButtonActive : styles.tabButton}
-          onClick={() => { setMode("spotify"); onChange(undefined); setManualName(""); setManualArtist(""); }}
+          onClick={() => { setMode("spotify"); handleRemoveAll(); }}
         >
           Search Spotify
         </button>
         <button
           type="button"
           className={mode === "manual" ? styles.tabButtonActive : styles.tabButton}
-          onClick={() => { setMode("manual"); onChange(undefined); setQuery(""); setResults([]); setShowDropdown(false); }}
+          onClick={() => { setMode("manual"); handleRemoveAll(); setResults([]); setShowDropdown(false); }}
         >
           Enter manually
         </button>
@@ -196,47 +177,95 @@ export function SpotifySearch({ value, onChange }: SpotifySearchProps) {
 
       {mode === "spotify" ? (
         <div>
-          <input
-            className={styles.searchInput}
-            type="text"
-            placeholder="Search for artists, albums, or tracks..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onFocus={() => { if (results.length > 0) setShowDropdown(true); }}
-            aria-label="Search Spotify"
-          />
-          {showDropdown && (
-            <div className={styles.dropdown} role="listbox" data-testid="spotify-dropdown">
-              {loading && <div className={styles.loading}>Searching...</div>}
-              {!loading && searched && results.length === 0 && (
-                <div className={styles.noResults}>No results found</div>
-              )}
-              {results.map((item, index) => (
-                <button
-                  key={`${item.spotifyId}-${item.type}`}
-                  type="button"
-                  role="option"
-                  aria-selected={index === activeIndex}
-                  className={index === activeIndex ? styles.resultItemActive : styles.resultItem}
-                  onClick={() => handleSelect(item)}
-                >
-                  {item.imageUrl && isValidSpotifyImage(item.imageUrl) ? (
-                    <img className={styles.thumbnail} src={item.imageUrl} alt="" />
-                  ) : (
-                    <div className={styles.thumbnailPlaceholder}>&#9835;</div>
-                  )}
-                  <div className={styles.resultInfo}>
-                    <div className={styles.resultName}>{item.name}</div>
-                    {item.artistName && (
-                      <div className={styles.resultSubtext}>{item.artistName}</div>
+          {spotifyItems.length > 0 && (
+            <div className={styles.chipList} data-testid="spotify-chip-list">
+              {spotifyItems.map((item, idx) => {
+                const originalIndex = value.indexOf(item);
+                return (
+                  <div key={`${item.spotifyId}-${item.type}`} className={styles.chip} data-testid="spotify-chip">
+                    {item.imageUrl && isValidSpotifyImage(item.imageUrl) && (
+                      <img
+                        className={styles.chipImage}
+                        src={item.imageUrl}
+                        alt={item.name}
+                      />
                     )}
+                    <div className={styles.chipInfo}>
+                      <div className={styles.chipName}>{item.name}</div>
+                      {item.artistName && (
+                        <div className={styles.chipSubtext}>{item.artistName}</div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.chipRemove}
+                      onClick={() => handleRemove(originalIndex)}
+                      aria-label={`Remove ${item.name}`}
+                    >
+                      x
+                    </button>
                   </div>
-                  <span className={styles.typeBadge}>{item.type}</span>
-                </button>
-              ))}
-              <div className={styles.attribution}>Powered by Spotify</div>
+                );
+              })}
             </div>
+          )}
+
+          {!atMax && (
+            <>
+              <input
+                className={styles.searchInput}
+                type="text"
+                placeholder={spotifyItems.length > 0
+                  ? `Add another (${spotifyItems.length}/${MAX_AUDIO_SELECTIONS})...`
+                  : "Search for artists, albums, or tracks..."}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onFocus={() => { if (results.length > 0) setShowDropdown(true); }}
+                aria-label="Search Spotify"
+              />
+              {showDropdown && (
+                <div className={styles.dropdown} role="listbox" data-testid="spotify-dropdown">
+                  {loading && <div className={styles.loading}>Searching...</div>}
+                  {!loading && searched && results.length === 0 && (
+                    <div className={styles.noResults}>No results found</div>
+                  )}
+                  {results.map((item, index) => {
+                    const selected = isAlreadySelected(item);
+                    return (
+                      <button
+                        key={`${item.spotifyId}-${item.type}`}
+                        type="button"
+                        role="option"
+                        aria-selected={index === activeIndex}
+                        className={index === activeIndex ? styles.resultItemActive : styles.resultItem}
+                        onClick={() => handleSelect(item)}
+                        disabled={selected}
+                        style={selected ? { opacity: 0.5 } : undefined}
+                      >
+                        {item.imageUrl && isValidSpotifyImage(item.imageUrl) ? (
+                          <img className={styles.thumbnail} src={item.imageUrl} alt="" />
+                        ) : (
+                          <div className={styles.thumbnailPlaceholder}>&#9835;</div>
+                        )}
+                        <div className={styles.resultInfo}>
+                          <div className={styles.resultName}>{item.name}</div>
+                          {item.artistName && (
+                            <div className={styles.resultSubtext}>{item.artistName}</div>
+                          )}
+                        </div>
+                        <span className={styles.typeBadge}>{item.type}</span>
+                      </button>
+                    );
+                  })}
+                  <div className={styles.attribution}>Powered by Spotify</div>
+                </div>
+              )}
+            </>
+          )}
+
+          {atMax && (
+            <div className={styles.maxMessage}>Maximum of {MAX_AUDIO_SELECTIONS} selections reached</div>
           )}
         </div>
       ) : (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import { WeeklyDistanceChart } from "../components/Dashboard/WeeklyDistanceChart
 import { MonthlyDistanceChart } from "../components/Dashboard/MonthlyDistanceChart";
 import { formatDuration, formatPace, formatDate, formatDateTime, formatCalories, formatAudio } from "../utils/format";
 import type { Run } from "../types/run";
+import { normalizeAudio } from "../types/audio";
 import type { WeeklyDistance, MonthlyDistance } from "../types/stats";
 import shared from "../styles/shared.module.css";
 import styles from "../styles/Dashboard.module.css";
@@ -125,10 +126,10 @@ export function Dashboard() {
                 <span>{formatCalories(run.caloriesBurned)}</span>
               )}
             </div>
-            {run.audio && (
+            {normalizeAudio(run.audio).length > 0 && (
               <div className={shared.audioLine}>
                 {"🎵"}{" "}
-                {formatAudio(run.audio)}
+                {formatAudio(normalizeAudio(run.audio)[0])}
               </div>
             )}
           </div>

--- a/frontend/src/pages/NewRunPage.tsx
+++ b/frontend/src/pages/NewRunPage.tsx
@@ -4,7 +4,7 @@ import { createRun } from "../api/client";
 import { RunMap } from "../components/Map/RunMap";
 import { SpotifySearch } from "../components/Spotify/SpotifySearch";
 import { calculateRouteDistance, formatDistance } from "../utils/distance";
-import type { AudioRef } from "../types/audio";
+import type { AudioRefs } from "../types/audio";
 import type { Coordinate, CreateRunPayload } from "../types/run";
 import shared from "../styles/shared.module.css";
 import styles from "../styles/NewRunPage.module.css";
@@ -43,7 +43,7 @@ export function NewRunPage() {
     setDistanceMeters(calculateRouteDistance(coords));
   }, []);
 
-  const [audio, setAudio] = useState<AudioRef | undefined>(undefined);
+  const [audio, setAudio] = useState<AudioRefs>([]);
 
   function parseDuration(input: string): number | null {
     if (!input.trim()) return null;
@@ -73,7 +73,7 @@ export function NewRunPage() {
       ...(route.length >= 2 ? { route, distanceMeters } : {}),
       ...(status === "completed" && durationSeconds ? { durationSeconds } : {}),
       ...(notes.trim() ? { notes: notes.trim() } : {}),
-      ...(audio ? { audio } : {}),
+      ...(audio.length > 0 ? { audio } : {}),
     };
 
     try {

--- a/frontend/src/pages/RunDetailPage.tsx
+++ b/frontend/src/pages/RunDetailPage.tsx
@@ -5,7 +5,8 @@ import { RouteMap } from "../components/Map/RouteMap";
 import { SpotifySearch } from "../components/Spotify/SpotifySearch";
 import { formatDuration, formatPace, formatDateTime, formatCalories, formatAudio } from "../utils/format";
 import type { Run, UpdateRunPayload } from "../types/run";
-import type { AudioRef } from "../types/audio";
+import type { AudioRef, AudioRefs } from "../types/audio";
+import { normalizeAudio } from "../types/audio";
 import shared from "../styles/shared.module.css";
 import styles from "../styles/RunDetailPage.module.css";
 
@@ -40,7 +41,7 @@ export function RunDetailPage() {
   const [editDuration, setEditDuration] = useState("");
   const [editDistance, setEditDistance] = useState("");
   const [editElevation, setEditElevation] = useState("");
-  const [editAudio, setEditAudio] = useState<AudioRef | undefined>(undefined);
+  const [editAudio, setEditAudio] = useState<AudioRefs>([]);
   const [audioRemoved, setAudioRemoved] = useState(false);
   const [saving, setSaving] = useState(false);
 
@@ -64,7 +65,7 @@ export function RunDetailPage() {
     setEditDuration(data.durationSeconds ? formatDurationInput(data.durationSeconds) : "");
     setEditDistance(data.distanceMeters ? (data.distanceMeters / 1000).toFixed(2) : "");
     setEditElevation(data.elevationGainMeters !== undefined ? String(data.elevationGainMeters) : "");
-    setEditAudio(data.audio);
+    setEditAudio(normalizeAudio(data.audio));
     setAudioRemoved(false);
   }
 
@@ -78,9 +79,9 @@ export function RunDetailPage() {
     setEditing(false);
   }
 
-  function handleAudioChange(audio: AudioRef | undefined) {
+  function handleAudioChange(audio: AudioRefs) {
     setEditAudio(audio);
-    setAudioRemoved(!audio);
+    setAudioRemoved(audio.length === 0);
   }
 
   async function handleSaveEdit() {
@@ -138,7 +139,7 @@ export function RunDetailPage() {
 
       if (audioRemoved) {
         payload.audio = null;
-      } else if (editAudio) {
+      } else if (editAudio.length > 0) {
         payload.audio = editAudio;
       }
 
@@ -325,46 +326,45 @@ export function RunDetailPage() {
               )}
             </div>
 
-            {run.audio && run.audio.source === "spotify" && (
+            {normalizeAudio(run.audio).length > 0 && (
               <div className={styles.section}>
                 <div className={styles.sectionLabel}>Music</div>
-                <div className={styles.spotifyCard}>
-                  {run.audio.imageUrl?.startsWith("https://i.scdn.co/") && (
-                    <img
-                      className={styles.spotifyArt}
-                      src={run.audio.imageUrl}
-                      alt={run.audio.name}
-                    />
-                  )}
-                  <div className={styles.spotifyInfo}>
-                    <div className={styles.spotifyTrack}>{run.audio.name}</div>
-                    {run.audio.artistName && (
-                      <div className={styles.spotifyArtist}>{run.audio.artistName}</div>
-                    )}
-                    {run.audio.albumName && (
-                      <div className={styles.spotifyAlbum}>{run.audio.albumName}</div>
-                    )}
-                    {run.audio.spotifyUrl?.startsWith("https://open.spotify.com/") && (
-                      <a
-                        href={run.audio.spotifyUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={styles.spotifyLink}
-                      >
-                        Open in Spotify
-                      </a>
-                    )}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {run.audio && run.audio.source === "manual" && (
-              <div className={styles.section}>
-                <div className={styles.sectionLabel}>Music</div>
-                <div className={styles.sectionValue}>
-                  {formatAudio(run.audio)}
-                </div>
+                {normalizeAudio(run.audio).map((item, idx) =>
+                  item.source === "spotify" ? (
+                    <div key={idx} className={styles.spotifyCard}>
+                      {item.imageUrl?.startsWith("https://i.scdn.co/") && (
+                        <img
+                          className={styles.spotifyArt}
+                          src={item.imageUrl}
+                          alt={item.name}
+                        />
+                      )}
+                      <div className={styles.spotifyInfo}>
+                        <div className={styles.spotifyTrack}>{item.name}</div>
+                        {item.artistName && (
+                          <div className={styles.spotifyArtist}>{item.artistName}</div>
+                        )}
+                        {item.albumName && (
+                          <div className={styles.spotifyAlbum}>{item.albumName}</div>
+                        )}
+                        {item.spotifyUrl?.startsWith("https://open.spotify.com/") && (
+                          <a
+                            href={item.spotifyUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.spotifyLink}
+                          >
+                            Open in Spotify
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <div key={idx} className={styles.sectionValue}>
+                      {formatAudio(item)}
+                    </div>
+                  )
+                )}
               </div>
             )}
 

--- a/frontend/src/types/audio.ts
+++ b/frontend/src/types/audio.ts
@@ -16,3 +16,17 @@ export interface ManualAudioRef {
 }
 
 export type AudioRef = SpotifyRef | ManualAudioRef;
+
+export type AudioRefs = AudioRef[];
+
+export const MAX_AUDIO_SELECTIONS = 3;
+
+/**
+ * Normalize audio from the backend — handles both legacy single-object
+ * format and new array format for backward compatibility.
+ */
+export function normalizeAudio(audio: AudioRef | AudioRef[] | undefined | null): AudioRef[] {
+  if (!audio) return [];
+  if (Array.isArray(audio)) return audio;
+  return [audio];
+}

--- a/frontend/src/types/run.ts
+++ b/frontend/src/types/run.ts
@@ -1,4 +1,4 @@
-import type { AudioRef } from "./audio";
+import type { AudioRef, AudioRefs } from "./audio";
 
 export type Coordinate = [number, number]; // [lng, lat] — MapLibre convention
 
@@ -14,7 +14,7 @@ export interface Run {
   durationSeconds?: number;
   elevationGainMeters?: number;
   notes?: string;
-  audio?: AudioRef;
+  audio?: AudioRef | AudioRefs;
   paceSecondsPerKm?: number;
   caloriesBurned?: number;
 }
@@ -28,7 +28,7 @@ export interface CreateRunPayload {
   durationSeconds?: number;
   elevationGainMeters?: number;
   notes?: string;
-  audio?: AudioRef;
+  audio?: AudioRefs;
 }
 
 export interface UpdateRunPayload {
@@ -39,7 +39,7 @@ export interface UpdateRunPayload {
   distanceMeters?: number;
   durationSeconds?: number;
   elevationGainMeters?: number;
-  audio?: AudioRef | null;
+  audio?: AudioRefs | null;
 }
 
 export interface CompleteRunPayload {


### PR DESCRIPTION
Implements feature #97.

## Changes

### Data model
- `frontend/src/types/audio.ts`: added `AudioRefs = AudioRef[]` type and `normalizeAudio()` helper for backward compatibility with old single-item runs

### SpotifySearch component
- Multi-select mode: select up to 3 items (artist, album, track in any combo)
- Search stays open after first selection
- Each selected item shown as a removable chip
- Manual mode unchanged (single-item)

### Consumers updated
- `NewRunPage.tsx`: uses `AudioRef[]` 
- `RunDetailPage.tsx`: displays multiple audio cards in view mode, edit mode supports multi-select

### Backend
- Accepts `audio` as either single object or array (backward compat)

### Tests
- Unit tests for multi-select behavior
- Tests for `normalizeAudio()` helper
- Updated existing tests

Closes #97