### PR TITLE
fix: Add bot_id and bot_name to claude-code-action config

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -50,6 +50,8 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude"
           allowed_bots: "runmaprepeat-autofix[bot],github-actions[bot]"
+          bot_id: "270995726"
+          bot_name: "runmaprepeat-autofix"
 
       - name: Gather fix summary
         if: always()


### PR DESCRIPTION
## Problem

The auto-fix workflow keeps failing with:
```
Failed to fetch user display name for runmaprepeat-autofix[bot]
Command failed: git fetch origin --depth=20 feat/spotify-multiselect-ux
```

## Root Cause

Per the [claude-code-action FAQ](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md#why-am-i-getting-403-resource-not-accessible-by-integration-errors):

> GitHub App tokens have limited access and cannot access the `/user` endpoint. The action now includes `bot_id` and `bot_name` inputs. For custom bots, specify both.

Our `runmaprepeat-autofix` is a custom GitHub App, not the default `claude[bot]`, so it needs explicit identification.

## Fix

Added `bot_id: 270995726` and `bot_name: runmaprepeat-autofix` to the action config.

Refs: #98