### PR TITLE
fix: Add checkout step to auto-fix workflow

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -41,6 +41,12 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
       - name: Run Claude Code
         id: claude-fix
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
The claude-code-action fails with `fatal: not a git repository` because no checkout step exists. Adding `actions/checkout@v4` with App token and full depth.

Refs: #98