### PR TITLE
fix: Don't cancel in-progress auto-fix runs

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: claude-fix-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
Skipped runs were cancelling real fix runs via concurrency group. Changed to `cancel-in-progress: false`.

Refs: #98