### PR TITLE
fix: Add App bot login to claude-fix if condition

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -23,6 +23,7 @@ jobs:
       contains(github.event.comment.body, '@claude') &&
       (
         github.event.comment.user.login == 'github-actions[bot]' ||
+        github.event.comment.user.login == 'runmaprepeat-autofix[bot]' ||
         github.event.comment.user.type == 'Bot'
       ) &&
       !contains(github.event.issue.labels.*.name, 'no-auto-fix')


### PR DESCRIPTION
The claude-fix workflow skips because `github.event.comment.user.type` may not be available in the `issue_comment` webhook payload. Adding `runmaprepeat-autofix[bot]` as an explicit login match.

Refs: #98