### PR TITLE
docs: deduplicate steering files — single ownership per rule

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -19,7 +19,5 @@ globs: backend/**
 - Type N sort keys need actual numbers, not strings
 
 ## Testing
-- Every handler needs pytest coverage: all HTTP methods, success/error/validation/edge cases
-- Target >90% handler coverage
 - Run: `cd backend && pytest -v`
-- PRs without adequate test coverage will be rejected
+- Coverage requirements: see CLAUDE.md § Testing Requirements

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -14,6 +14,5 @@ globs: frontend/**
 - Use `const` by default, `let` only when mutation is needed
 
 ## Testing
-- Every new component needs Vitest unit tests + Playwright E2E for user flows
 - Run: `cd frontend && npm run test`
-- PRs without adequate test coverage will be rejected
+- Coverage requirements: see CLAUDE.md § Testing Requirements

--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -6,19 +6,16 @@ globs: infra/**
 # Infrastructure Conventions
 
 - One stack per logical grouping (auth, api, frontend, data, location)
-- No hardcoded account IDs, ARNs, or secrets — use SSM Parameter Store or CDK context
+- Parameters via SSM Parameter Store or CDK context
 - Graviton/ARM64 for all Lambda functions
 - Removal policy: RETAIN for DynamoDB tables
 - CDK assertions for all stack tests: `cd infra && cdk synth --quiet`
-
-## Security
-- NEVER make S3 buckets public — serve through CloudFront only
-- NEVER disable Cognito authorizer on API Gateway routes
-- NEVER allow self-registration on Cognito user pool
-- NEVER use `Principal: "*"` without scoped conditions
-- HTTPS everywhere, DynamoDB access scoped by userId
 
 ## CodeBuild
 - Always use `$CODEBUILD_SRC_DIR` — `cd` doesn't persist between phases
 - Never use `|| echo` on critical deploy commands — silently swallows failures
 - ARM64 cross-compilation needs `docker buildx` + `binfmt`
+
+## Security
+- See `.claude/rules/security.md` for all security prohibitions
+- HTTPS everywhere, DynamoDB access scoped by userId

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,70 +20,23 @@ API Gateway (Cognito authorizer) → Lambda (Python) → DynamoDB
 AWS Location Service (maps + route calculator)
 ```
 
-## Coding Conventions
+## Conventions
+- **Coding rules:** see CLAUDE.md and `.claude/rules/`
+- **Workflow & merge rules:** see WORKFLOW.md
+- **Security:** see `.claude/rules/security.md`
+- **Testing requirements:** see CLAUDE.md § Testing Requirements
 
-### Frontend (TypeScript/React)
-- Functional components only, hooks for state
-- No class components
-- Use `const` by default, `let` only when mutation is needed
-- Strict TypeScript — no `any` unless absolutely necessary
-- File naming: `PascalCase.tsx` for components, `camelCase.ts` for utilities
-- CSS: CSS modules or inline styles (no CSS-in-JS libraries)
-- All API calls go through a central `api/` module
-- Error boundaries on route-level components
-
-### Backend (Python/Lambda)
-- Python 3.12+
-- Type hints on all function signatures
-- Handlers return `{ statusCode, headers, body }` format
-- All DynamoDB access through a data access layer (not inline in handlers)
-- Validate Cognito `sub` from JWT for all user-scoped operations
-- Use `boto3` resource API where practical, client API for fine control
-- Logging via `structlog` or stdlib `logging` — no print statements
-
-### Infrastructure (CDK Python)
-- One stack per logical grouping (auth, api, frontend, data, location)
-- No hardcoded account IDs, ARNs, or secrets
-- Parameters via SSM Parameter Store or CDK context
-- Graviton/ARM64 for all Lambda functions
-- Always set removal policy to RETAIN for DynamoDB tables
-
-### General
-- Every new feature needs tests (unit at minimum)
-- No `console.log` or `print` in committed code (use proper logging)
+### General (all agents)
 - Commit messages: conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, `test:`)
 - Branch naming: `feat/description`, `fix/description`, `chore/description`
 - Never commit `.env`, `node_modules/`, `__pycache__/`, `cdk.out/`, `dist/`
-
-## Security Rules
-- **NEVER** hardcode secrets or credentials — use Secrets Manager or SSM
-- **NEVER** make S3 buckets public — serve through CloudFront only
-- **NEVER** disable Cognito authorizer on API Gateway routes
-- **NEVER** allow self-registration on Cognito user pool
-- **NEVER** use `Principal: "*"` in resource policies without scoped conditions
-- All API endpoints require authentication
-- DynamoDB access scoped by userId (Cognito sub)
-- HTTPS everywhere
-- Follow SLATS security rules (Global + Internal) for all AWS resources
-
-## Testing
-- Frontend: Vitest + React Testing Library + Playwright (E2E)
-- Backend: pytest
-- Infrastructure: CDK assertions (`aws_cdk.assertions`)
-- Tests must pass before merge — enforced by CI
-
-### Coverage Requirements (enforced during code review)
-- **All new functionality MUST include tests** — features, bug fixes, refactors. No exceptions.
-- **Bug fixes MUST include a regression test** that would have caught the bug before the fix.
-- **"Tests pass" is not enough** — reviewers must verify that new/changed code paths are actually covered by tests, not just that existing tests still pass.
-- **Frontend:** Every new page/component MUST have Playwright E2E tests covering core user flows + Vitest unit tests for utilities and component rendering.
-- **Backend:** Every Lambda handler MUST have pytest coverage for all HTTP methods, success paths, error paths, validation errors, and edge cases. Data layer changes need their own tests (not just handler-level mocks). Aim for >90% handler coverage.
-- **PRs without adequate test coverage will be rejected during review.**
+- Don't add unnecessary dependencies — check if stdlib or existing deps cover it
+- Ask rather than guess if requirements are ambiguous
 
 ## What NOT to Do
-- Don't add unnecessary dependencies (check if stdlib or existing deps cover it)
 - Don't create IAM users — Cognito only
-- Don't use `any` in TypeScript
 - Don't skip error handling
-- Don't write Lambda handlers longer than ~100 lines — split into modules
 - Don't modify CDK-generated resource names manually
+- Don't use `any` in TypeScript
+- Don't use `print()` in Python — use proper logging
+- For security prohibitions, see `.claude/rules/security.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,6 @@
 
 Personal exercise run tracker. Draw routes on a map → distance, pace, calories.
 
-## Architecture
-```
-CloudFront → S3 (React SPA)
-API Gateway (Cognito authorizer) → Lambda (Python) → DynamoDB
-AWS Location Service (maps + route calculator)
-```
-
 ## Build & Test (run these to verify your work)
 ```bash
 # Frontend
@@ -21,14 +14,23 @@ cd backend && pip install -r requirements.txt -r requirements-dev.txt && pytest 
 cd infra && pip install -r requirements.txt && cdk synth --quiet
 ```
 
-## Key Rules
-- **Open a GitHub issue first** — every feature or bug fix starts with a tracked issue before any implementation. Include scope, design, and acceptance criteria. Reference the issue number in branch names and commits.
-- **Run tests before finishing** — always verify, never trust blindly
-- **All new code and bug fixes MUST have tests** — no exceptions. Bug fixes need a regression test that would have caught the original bug. "Tests pass" ≠ "new code is tested."
-- **Data layer changes need their own tests** — don't just mock at the handler level; test the actual functions that touch DynamoDB.
+## Workflow
+- **Open a GitHub issue first** — every feature or bug fix starts with a tracked issue. Include scope, design, and acceptance criteria. Reference the issue number in branch names and commits.
+- **Plan before code** — explore → plan → implement → verify. Complex changes need a planning phase; trivial changes can skip it.
 - **Small, focused commits** — conventional commits: `feat:`, `fix:`, `test:`, `chore:`, `docs:`
+- **Run tests before finishing** — always verify, never trust blindly
+- **Merge and deployment rules** — see WORKFLOW.md
+
+## Testing Requirements
+- **All new code and bug fixes MUST have tests** — no exceptions. Bug fixes need a regression test that would have caught the original bug.
+- **"Tests pass" ≠ "new code is tested"** — reviewers verify new/changed code paths are actually covered.
+- **Frontend:** Every new page/component needs Playwright E2E tests for core user flows + Vitest unit tests for utilities and rendering.
+- **Backend:** Every handler needs pytest coverage for all HTTP methods, success/error/validation/edge cases. Data layer changes need their own tests (not just handler-level mocks). Target >90% handler coverage.
+- **PRs without adequate test coverage will be rejected during review.**
+
+## Key Rules
 - **Never modify `infra/` without explicit instructions** — infrastructure changes need review
-- **Never hardcode** secrets, API keys, account IDs, or ARNs
+- **Never hardcode** secrets, API keys, account IDs, or ARNs — see `.claude/rules/security.md`
 - **No `any` in TypeScript**, no `print()` in Python — use proper types and logging
 - **Ask rather than guess** if requirements are ambiguous
 
@@ -56,23 +58,3 @@ infra/        AWS CDK (Python)
 - `$CODEBUILD_SRC_DIR` required in buildspec.yml — `cd` doesn't persist between phases
 - Cognito `sub` from JWT is the userId for all user-scoped DynamoDB operations
 - Lambda handlers must return `{ statusCode, headers, body }` — body is always a JSON string
-
-## Merge Gate Rules
-- **NEVER merge a PR where `Trigger Auto-Fix` job has `conclusion: failure`** — this means the auto-fix pipeline is broken and HIGH/CRITICAL findings were not addressed
-- **NEVER merge a PR with unresolved HIGH or CRITICAL AI review findings** — read the review comment, not just the green checkmark
-- **ALL CI jobs must be `success` or legitimately `skipped`** — `failure` on any job is a merge blocker, even if the overall workflow appears green
-- **NEVER use `gh pr merge --admin`** — if the PR can't merge normally, fix the blocker first
-- **NEVER dismiss HIGH/CRITICAL as "false positive" to justify merging** — if it's truly a false positive, document it in a PR comment and add the `no-auto-fix` label, but still get the finding resolved or explicitly acknowledged
-- When in doubt: `gh pr view <PR#> --json statusCheckRollup,reviews` and read the actual findings
-
-## Deployment Rules
-- **NEVER apply fixes directly to production** (Lambda env vars, configs, etc.)
-- **ALL changes go through IaC (CDK)** — commit, PR, review, merge, deploy via pipeline
-- Hotfixes are not hotfixes — they get overwritten on next deploy and create drift
-- If something is broken in prod, fix it in code and deploy through the pipeline
-
-## PR Merge Rules
-- **NEVER merge a PR with unresolved CRITICAL or HIGH findings** — no exceptions
-- If the auto-fix agent didn't run or failed, fix manually before merging
-- Wait for the review agent to complete and confirm "✅ Ready for Merge" before merging
-- If unsure, re-run the review after fixes and verify zero CRITICAL/HIGH findings

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -19,24 +19,24 @@
         ↓
 4. Claude Code implements on a feature branch, commits + pushes
         ↓
-4. Loki opens PR (or Claude Code does via gh cli)
+5. Loki opens PR (or Claude Code does via gh cli)
         ↓
-5. GitHub Actions runs tests automatically, notifies Loki via Telegram
+6. GitHub Actions runs tests automatically, notifies Loki via Telegram
         ↓
-6. Loki reviews the PR:
+7. Loki reviews the PR:
    - Reads the diff (gh pr diff)
    - Checks test results
-   - Reviews against project standards (AGENTS.md)
+   - Reviews against project standards
    - Posts: APPROVE / REQUEST_CHANGES / COMMENT on the PR
         ↓
-7a. If APPROVE → Loki merges (or notifies Barak for manual merge)
-7b. If REQUEST_CHANGES → Loki spawns Claude Code to fix
+8a. If APPROVE → Loki merges (or notifies Barak for manual merge)
+8b. If REQUEST_CHANGES → Loki spawns Claude Code to fix
         ↓
-8. Claude Code pushes fixes to same branch
+9. Claude Code pushes fixes to same branch
         ↓
-9. CI re-runs tests, Loki re-reviews (back to step 5)
+10. CI re-runs tests, Loki re-reviews (back to step 6)
         ↓
-10. On merge → CodePipeline deploys → Telegram notification
+11. On merge → CodePipeline deploys → Telegram notification
 ```
 
 ## Branch Strategy
@@ -49,26 +49,29 @@
 
 **A PR may ONLY be merged when ALL of the following are true:**
 
-1. ✅ **All CI jobs passed** — every job in the workflow must show `conclusion: success` or `conclusion: skipped` (legitimate skip only)
-2. ✅ **No CRITICAL or HIGH findings** from AI Code Review — if the review flagged HIGH or CRITICAL, they must be resolved first
-3. ✅ **Auto-Fix job did NOT fail** — if `Trigger Auto-Fix` has `conclusion: failure`, that means the fix pipeline is broken and findings were NOT addressed. **DO NOT MERGE.** Investigate the failure first.
-4. ✅ **No unresolved review comments** requesting changes
+1. ✅ All CI jobs passed — every job must show `success` or `skipped` (legitimate skip only)
+2. ✅ No CRITICAL or HIGH findings from AI Code Review
+3. ✅ Auto-Fix job did NOT fail — `failure` means findings were NOT addressed. Investigate first.
+4. ✅ No unresolved review comments requesting changes
 
 **Explicit blockers (never merge if any of these are true):**
-- ❌ `Trigger Auto-Fix` job failed (not skipped — *failed*). This means HIGH findings exist but auto-fix couldn't run. Treat as a merge blocker.
-- ❌ AI Review flagged HIGH/CRITICAL and no follow-up fix commit addressed them
+- ❌ `Trigger Auto-Fix` job failed (not skipped — *failed*)
+- ❌ AI Review flagged HIGH/CRITICAL with no follow-up fix
 - ❌ Any required CI job failed (even if `continue-on-error` made the workflow green)
-- ❌ **NEVER use `--admin` to bypass merge gates** — if the PR can't merge normally, fix the issue first
-- ❌ **NEVER rationalize HIGH/CRITICAL findings as "false positives" to justify merging** — if you believe it's a false positive, add the `no-auto-fix` label and document why in a PR comment, but still fix or explicitly acknowledge the finding before merging
+- ❌ NEVER use `--admin` to bypass merge gates
+- ❌ NEVER rationalize HIGH/CRITICAL findings as "false positives" to justify merging — add `no-auto-fix` label and document why, but still fix or acknowledge
 
-**How to check before merging:**
+**How to check:**
 ```bash
-# Verify all jobs — look for conclusion: failure on ANY job
 gh pr view <PR#> --json statusCheckRollup --jq '.statusCheckRollup[] | {name, status, conclusion}'
-
-# Read the AI review comment for severity levels
 gh pr view <PR#> --json reviews --jq '.reviews[] | select(.author.login=="github-actions") | .body'
 ```
+
+## Deployment Rules
+- **NEVER apply fixes directly to production** (Lambda env vars, configs, etc.)
+- **ALL changes go through IaC (CDK)** — commit, PR, review, merge, deploy via pipeline
+- Hotfixes are not hotfixes — they get overwritten on next deploy and create drift
+- If something is broken in prod, fix it in code and deploy through the pipeline
 
 ### General PR rules
 - All PRs require passing PR Review workflow


### PR DESCRIPTION
## What
Deduplicated rules across all steering files. Each rule now lives in exactly one file.

## Changes
- **CLAUDE.md** (78→60 lines): Removed duplicate merge rules, deployment rules, architecture diagram. Added 'Plan before code'. Consolidated testing requirements here as the single source.
- **WORKFLOW.md** (82→85 lines): Absorbed deployment rules from CLAUDE.md. Already owned merge rules — no duplication now.
- **AGENTS.md** (89→42 lines): Stripped all backend/frontend/infra/security convention duplicates. Now just project context + cross-references.
- **.claude/rules/backend.md**: Links to CLAUDE.md for coverage requirements instead of repeating them.
- **.claude/rules/frontend.md**: Same — links to CLAUDE.md for coverage.
- **.claude/rules/infrastructure.md**: Links to security.md instead of repeating S3/Principal rules.

## Why
Same rules appeared in 2-4 files with slightly different wording. This creates drift risk and wastes agent context window. Now: one owner per rule, cross-references everywhere else.

**Net: -125 lines added, +57 = 68 fewer lines total.**