### PR TITLE
infra: Bedrock application inference profiles for AI review workflows

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -54,7 +54,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
-          claude_args: "--model sonnet --max-turns 25"
+          claude_args: "--model arn:aws:bedrock:us-east-1:579083551251:application-inference-profile/2b0oullfks5k --max-turns 25"
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude"
           allowed_bots: "runmaprepeat-autofix[bot],github-actions[bot]"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -200,6 +200,7 @@ jobs:
           NOTIFY_CHANNEL: "telegram"
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          MODEL_ID: "arn:aws:bedrock:us-east-1:579083551251:application-inference-profile/x2ntqs4tet2b"
         run: python .github/scripts/ai_review.py
 
   # ================================================================


### PR DESCRIPTION
## Summary

Creates two Bedrock **application inference profiles** for the AI code review workflows, enabling per-workflow cost tracking and independent throttling/budget controls.

## Profiles Created

| Profile | ARN | Used By |
|---------|-----|---------|
| `runmaprepeat-pr-review` | `...x2ntqs4tet2b` | `pr-review.yml` (Opus 4.6) |
| `runmaprepeat-auto-fix` | `...2b0oullfks5k` | `claude-fix.yml` (Sonnet 4.6) |

Both tagged: `Project=runmaprepeat`, `Environment=prod`, `Owner=barakcaf`.

## Changes

- `pr-review.yml`: adds `MODEL_ID` env var pointing to `runmaprepeat-pr-review` profile
- `claude-fix.yml`: updates `--model` arg to `runmaprepeat-auto-fix` profile ARN

## IAM

The existing `github-actions-ai-review` OIDC role policy already covers `arn:aws:bedrock:*:579083551251:inference-profile/*` — no IAM changes needed.

## Why

Cost Explorer now shows AI review costs broken down by workflow (not lumped into a single model bucket). Enables setting separate Bedrock throttling policies or budgets per workflow in future.