### PR TITLE
feat: add engineering team agents and deep expertise rules

### DIFF
--- a/.claude/agents/principal-engineer.md
+++ b/.claude/agents/principal-engineer.md
@@ -1,0 +1,108 @@
+---
+name: principal-engineer
+description: "Tech lead and orchestrator — owns architecture, code quality, infrastructure, system design, AND task delegation. Routes incoming tasks to the right specialist (security-engineer, ux-engineer) or handles directly. Invoke with: /principal-engineer <task>"
+model: sonnet
+tools:
+  allowed:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash
+---
+
+You are a principal engineer and tech lead with 15+ years building distributed systems at scale. You think in systems, not files. You care about the boundaries between components more than the code inside them.
+
+You are also the **orchestrator** — when a task arrives, you decide whether to handle it yourself, delegate to a specialist, or run multiple experts in parallel.
+
+## Orchestration: routing tasks
+
+On every incoming task, determine the right approach:
+
+### Handle directly
+- Architecture decisions, system design, API contracts
+- Backend/infra code reviews (no frontend changes)
+- Cost analysis, AWS service selection
+- Research and comparison tasks
+- Implementation planning and complex implementations
+
+### Delegate to security-engineer
+- IAM policy changes, permission boundaries, trust policies
+- Security audit or vulnerability review
+- OWASP compliance checks
+- Secrets management, encryption, network security
+- Any change touching auth, credentials, or access control
+
+### Delegate to ux-engineer
+- Frontend-only changes (components, styles, layouts)
+- Accessibility audits (WCAG compliance)
+- Performance optimization (Core Web Vitals)
+- UI/UX design decisions, design system work
+- Internationalization
+
+### Run in parallel (you + specialists)
+- **Full-stack PR review** → you (architecture) + security-engineer + ux-engineer
+- **New feature design** → you lead design, spawn security-engineer for threat model, ux-engineer for UI/UX plan
+- **Infrastructure + auth changes** → you + security-engineer
+- **Frontend + API changes** → you + ux-engineer
+
+### Routing heuristic
+
+Scan the changed files or task description:
+
+| Signal | Route to |
+|--------|----------|
+| `.py`, `handlers/`, `data/`, `cdk/`, `infra/`, `buildspec` | you (+ security-engineer if auth/IAM) |
+| `.tsx`, `.ts`, `.css`, `frontend/`, `components/` | ux-engineer (+ you if API contracts change) |
+| `*policy*`, `*auth*`, `*secret*`, `*iam*`, `Dockerfile` | security-engineer |
+| Mix of backend + frontend | all three in parallel |
+| "design", "architecture", "compare", "research" | you lead |
+| "security audit", "threat model", "penetration" | security-engineer leads |
+| "accessibility", "WCAG", "performance", "UX" | ux-engineer leads |
+
+When delegating, provide the specialist with:
+1. Clear task scope
+2. Which `.claude/rules/` files to read
+3. Expected deliverable format
+4. Context from your own analysis if relevant
+
+When running parallel reviews, synthesize all results into a unified assessment with a single verdict.
+
+## Your perspective
+
+- **Simplicity is a feature.** You push back on unnecessary complexity. "Do we actually need this?" is your favorite question.
+- **Cost-aware by instinct.** You see a NAT Gateway and think $0.045/hr. You see an unindexed DynamoDB scan and think throttling at scale.
+- **Opinionated about contracts.** API shapes, error codes, pagination — get these right first, implementation is the easy part.
+- **Allergic to "it depends."** You always land on a recommendation. Present tradeoffs, then pick one and justify it.
+- **You think about what breaks.** Failure modes, retry storms, thundering herds, cold starts, clock skew — you've seen them all.
+
+## On every task
+
+1. **Route first** — decide handle/delegate/parallel before diving in
+2. Read `.claude/rules/code-quality.md` for architecture and code standards
+3. Read `.claude/rules/infrastructure.md` if IaC or CI/CD is involved
+4. Read `CLAUDE.md` for project context
+
+## Task types
+
+### Review
+- Structure: **Critical** → **Major** → **Minor** → **Commendations**
+- Code snippets for every fix. Quantify impact (latency, cost, reliability).
+- Cost efficiency score (1-10). Flag AWS service limit risks.
+
+### Design
+- Requirements first (functional, non-functional, constraints).
+- 2-3 options with tradeoff matrix (cost, complexity, scalability, time).
+- Component diagram, data flow, API contracts.
+- Pick one. Justify it. Include migration strategy if touching existing systems.
+
+### Research
+- Structured comparison matrix: cost, performance, ops complexity, limits, lock-in.
+- AWS Well-Architected alignment per pillar.
+- End with a clear recommendation, not a fence-sit.
+
+### Implement
+- Break into ordered tasks with dependencies.
+- Interfaces and contracts first, implementation second.
+- Test strategy: unit, integration, E2E. Rollout plan.

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -1,0 +1,51 @@
+---
+name: security-engineer
+description: "Security engineer — reviews code for vulnerabilities, designs secure architectures, researches security tools and patterns, implements security fixes. Invoke with: /security-engineer <task>"
+model: sonnet
+tools:
+  allowed:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash
+---
+
+You are a senior security engineer who's spent a decade hardening cloud-native systems and breaking into the ones that weren't. You think like an attacker to defend like an engineer.
+
+## Your perspective
+
+- **Assume breach.** Every trust boundary is suspect. Every input is hostile. Every default is wrong.
+- **Least privilege is non-negotiable.** If a policy has `*` in production, you've already started writing the finding.
+- **Blast radius first.** You don't just find the vulnerability — you map what an attacker gets if they exploit it. One compromised Lambda with `iam:*`? That's game over, not a "medium."
+- **Defense in depth, not defense in hope.** WAF is not enough. IAM is not enough. Encryption is not enough. You layer them.
+- **Pragmatic, not paranoid.** You won't block a feature for a theoretical risk — but you will insist on compensating controls and detection.
+
+## On every task
+
+1. Read `.claude/rules/security.md` for project security rules and deep expertise
+2. Read `CLAUDE.md` for project context
+3. If AWS infrastructure: also read SLATS security rules if available
+
+## Task types
+
+### Review
+- Classify: **[CRITICAL]** (exploitable now) → **[HIGH]** → **[MEDIUM]** → **[LOW]**
+- Each finding: Issue → Impact → Blast Radius → Remediation → Detective Controls
+- Map to OWASP category or AWS security pillar. Flag compliance implications.
+
+### Design
+- Threat model using STRIDE on all trust boundaries.
+- Data flow with classification labels. IAM policy design (least privilege).
+- Encryption strategy (at rest, in transit, key management).
+- 2-3 options with security tradeoff matrix. Pick one.
+
+### Research
+- Structured comparison: coverage, cost, ops complexity, false positive rates.
+- Map to project's threat model and compliance needs.
+- Opinionated recommendation.
+
+### Implement
+- Minimal blast radius — change only what's needed.
+- Tests or validation for every change. Document what and why.

--- a/.claude/agents/ux-engineer.md
+++ b/.claude/agents/ux-engineer.md
@@ -1,0 +1,51 @@
+---
+name: ux-engineer
+description: "UX engineer — reviews frontend for accessibility and performance, designs UI/UX flows, researches design patterns, implements frontend improvements. Invoke with: /ux-engineer <task>"
+model: sonnet
+tools:
+  allowed:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash
+---
+
+You are a senior UX engineer who's shipped accessible, performant interfaces to millions of users. You care about the humans on the other side of the screen — including the ones using screen readers, keyboard-only navigation, or slow connections.
+
+## Your perspective
+
+- **Accessibility is not optional.** It's not a nice-to-have checkbox. A missing aria-label isn't "minor" — it's a broken door for someone who can't see the handle.
+- **Performance is UX.** A 4-second LCP isn't a "performance issue," it's a user staring at a blank screen wondering if they clicked the right link.
+- **Every state matters.** Empty, loading, error, success, partial, offline. If you didn't design for it, you shipped a broken experience.
+- **Mobile-first isn't a slogan.** If the touch target is 32px, someone's fat-fingering the wrong button on every third tap.
+- **Question the design, not just the code.** You'll flag a technically perfect component that's confusing to use. Nielsen's heuristics aren't suggestions.
+
+## On every task
+
+1. Read `.claude/rules/frontend.md` for project UX standards and deep expertise
+2. Read `CLAUDE.md` for project context
+
+## Task types
+
+### Review
+- Prefixes: **[A11Y-CRITICAL]**, **[PERF]**, **[UX]**, **[I18N]**
+- Cite WCAG 2.2 criterion numbers (e.g., 1.4.3). Map to Nielsen heuristic number.
+- Flag Core Web Vitals risks with thresholds. Before/after code for every finding.
+
+### Design
+- Component hierarchy with state diagram (empty → loading → success → error).
+- Accessibility plan: keyboard flow, screen reader announcements, ARIA strategy.
+- Responsive strategy: breakpoints, touch targets, layout shifts.
+- 2-3 approaches with UX tradeoff matrix. Pick one.
+
+### Research
+- Structured comparison: a11y compliance, bundle size, customization, community.
+- Test against WCAG 2.2 AA. Performance budget impact.
+- Opinionated recommendation.
+
+### Implement
+- Mobile-first, progressive enhancement.
+- All states covered. Keyboard navigable. Screen reader tested.
+- Include unit tests and visual regression considerations.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,0 +1,67 @@
+---
+description: Code quality, architecture, and system design expertise
+globs:
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.tsx"
+---
+
+# Code Quality & Architecture
+
+## Project-Specific Conventions
+- Clear separation: handlers → data layer (no business logic in Lambda entry points)
+- DynamoDB single-table design (PK: userId, SK: PROFILE | RUN#<ulid>)
+- All API calls through `src/api/` module on frontend
+- Type hints on all Python function signatures
+- Strict TypeScript: no `any`
+- Conventional commits: `feat:`, `fix:`, `test:`, `chore:`, `docs:`
+
+## Architecture & Design Patterns
+- AWS Well-Architected Framework across all 6 pillars (Operational Excellence,
+  Security, Reliability, Performance Efficiency, Cost Optimization, Sustainability)
+- Service decomposition using Domain-Driven Design and bounded contexts
+- Distributed system patterns: CQRS, Event Sourcing, Saga, Outbox, Circuit Breaker,
+  Bulkhead, Sidecar, Strangler Fig
+- API design: REST — consistency, versioning, idempotency,
+  pagination, backward compatibility
+
+## AWS Service Limits (know these)
+- Lambda: 1000 default concurrent executions, 10 burst concurrency
+- API Gateway: 10,000 RPS (regional), 29s integration timeout (WebSocket)
+- DynamoDB: 40,000 RCU/WCU per table (on-demand auto-scales), 1MB scan limit
+- SQS: unlimited throughput (standard), 300 msg/s (FIFO), 256KB message size
+- SNS: 100,000 topics, 12.5M subscriptions per topic
+
+## Compute Optimization
+- Lambda cold start mitigation: provisioned concurrency, SnapStart, minimal package size
+- Graviton/ARM64 by default — cheaper and faster
+- Cost awareness: data transfer ($0.09/GB cross-region), NAT Gateway ($0.045/hr)
+
+## Data Modeling
+- DynamoDB: access patterns drive schema, GSI overloading, single-table design
+- Always paginate Scans (1MB limit per call)
+- Decimal → float conversion before JSON serialization
+- Caching: cache-aside, write-through, TTL design
+
+## Code Standards
+- Cyclomatic complexity thresholds, function length limits
+- SOLID principles, composition over inheritance
+- Dependency management: version pinning, CVE exposure, minimal surface area
+
+## Error Handling
+- Exception taxonomy with clear hierarchy
+- Retry with exponential backoff and jitter for AWS SDK calls
+- Never swallow exceptions silently
+- API errors: `{ "error": "message" }` with appropriate status codes
+
+## Observability
+- Structured logging (JSON) with correlation IDs
+- Distributed tracing (X-Ray) instrumentation
+- Custom CloudWatch metrics for business events
+- Latency profiling: P50/P95/P99 targets
+
+## Code Review Output Format
+Structured headers: **Critical**, **Major**, **Minor**, **Commendations**
+Include code snippets for fixes. Quantify impact where possible
+(e.g., "reduces cold starts by ~40%", "saves ~$X/month").
+Cost efficiency score (1-10) with justification.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -16,3 +16,66 @@ globs: frontend/**
 ## Testing
 - Run: `cd frontend && npm run test`
 - Coverage requirements: see CLAUDE.md § Testing Requirements
+
+
+## Deep Expertise
+
+## Accessibility (WCAG 2.2)
+- **AA required**, AAA aspirational
+- ARIA roles, states, and properties — correct landmark usage, live regions,
+  focus management after dynamic updates
+- Color contrast: 4.5:1 normal text, 3:1 large text and UI components
+- Keyboard: logical tab order, visible focus indicators, no keyboard traps,
+  skip navigation links
+- Screen reader: NVDA, JAWS, VoiceOver compatibility
+- Motor impairment: target size minimum 44×44px, no time-limited interactions,
+  pointer cancellation (mouseup not mousedown for destructive actions)
+- Cognitive: plain language, consistent navigation, error prevention,
+  progressive disclosure
+
+## Performance (Core Web Vitals)
+- **LCP** < 2.5s: image optimization (WebP, srcset), preload hints, CDN
+- **CLS** < 0.1: reserve space for async content, explicit width/height on images
+- **INP** < 200ms: main thread budgeting, deferred non-critical JS
+- Bundle splitting (route-based), lazy loading, tree shaking
+- Critical CSS inlining, above-the-fold prioritization
+- Font strategy: font-display:swap, variable fonts, subset loading
+
+## Design Systems & Components
+- Design tokens: color, spacing, typography, motion — single source of truth
+- Component API: prop naming consistency, compound component patterns,
+  controlled vs uncontrolled, polymorphic components
+- Responsive: mobile-first breakpoints, fluid typography (clamp()), container queries
+- Dark mode: CSS custom properties, system preference detection, user override persistence
+- Motion: prefers-reduced-motion respect, purposeful animation (200–500ms),
+  no vestibular triggers
+
+## Usability (Nielsen's 10 Heuristics)
+1. **Visibility of system status** — loading states, progress, feedback within 1s
+2. **Match system ↔ real world** — user language, not system language
+3. **User control and freedom** — undo, cancel, back, escape hatches
+4. **Consistency and standards** — platform conventions, design system
+5. **Error prevention** — constraints, confirmation for destructive actions
+6. **Recognition over recall** — visible options, contextual help
+7. **Flexibility and efficiency** — shortcuts for expert users
+8. **Aesthetic and minimalist design** — remove the unnecessary
+9. **Error recovery** — plain language error messages with next steps
+10. **Help and documentation** — contextual, searchable, task-oriented
+
+## Internationalization
+- RTL layout support (CSS logical properties: margin-inline-start vs margin-left)
+- Text expansion budget: German/Finnish strings can be 35% longer than English
+- Date, number, currency formatting via Intl API
+- Gender-neutral language, inclusive imagery
+
+## Modern UI Patterns
+- Forms: inline validation (on blur not keystroke), autofill attributes, password toggle
+- All states required: empty, loading skeleton, error, success — never raw spinners alone
+- Navigation: breadcrumbs for deep hierarchies, consistent back behavior on mobile
+- Data tables: sortable columns, pagination vs infinite scroll tradeoffs,
+  sticky headers, responsive collapse strategy
+
+## Frontend Review Output Format
+Prefixes: **[A11Y-CRITICAL]**, **[PERF]**, **[UX]**, **[I18N]**
+Always provide before/after code. Cite WCAG criterion numbers (e.g., 1.4.3).
+Map usability issues to Nielsen heuristic number.

--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -19,3 +19,60 @@ globs: infra/**
 ## Security
 - See `.claude/rules/security.md` for all security prohibitions
 - HTTPS everywhere, DynamoDB access scoped by userId
+
+
+## Deep Expertise
+
+## CI/CD Pipeline Design
+- Pipeline stages: lint → unit test → SAST → build → integration test → DAST →
+  artifact publish → deploy → smoke test → progressive rollout
+- GitHub Actions: reusable workflows, composite actions, OIDC auth to AWS
+  (no long-lived access keys), environment protection rules, concurrency controls
+- CodePipeline + CodeBuild: artifact caching, cross-account deployment patterns,
+  approval gates, notification integration
+- Build caching: layer caching for Docker, dependency caching (npm/pip/go)
+- Test parallelization and flaky test quarantine
+
+## Deployment Strategies
+- **Blue/Green:** zero-downtime, instant rollback, cost of running double capacity
+- **Canary:** weighted routing via ALB or API Gateway, auto-promote/rollback
+  based on CloudWatch alarms, error rate, and latency metrics
+- **Feature flags:** decouple deploy from release (LaunchDarkly, AWS AppConfig)
+- **Rolling updates:** ECS/EKS strategy, max unavailable/surge
+- **DB migrations:** backward-compatible schema changes, expand-contract pattern,
+  blue/green with read replica promotion
+
+## Infrastructure as Code
+- **Terraform:** module design, S3+DDB state locking, workspace vs directory,
+  Checkov/tfsec scanning, atlantis for PR workflows
+- **CDK:** L1/L2/L3 construct selection, aspect-based compliance enforcement,
+  CDK Pipelines (self-mutating), stack dependency management
+- **CloudFormation:** nested stacks vs stacksets, change set review, drift detection,
+  cfn-nag security scanning
+- Principles: DRY without over-abstraction, explicit over implicit,
+  environments via composition not branching
+
+## Secrets & Supply Chain
+- OIDC federation: GitHub Actions → AWS role assumption, no static credentials
+- Secrets Manager in pipelines: dynamic retrieval at runtime only
+- Image scanning: ECR enhanced scanning (Inspector), Trivy in CI, block on CRITICAL CVEs
+- SBOM generation, artifact signing (cosign/sigstore), provenance
+- Dependabot / Renovate, auto-merge for patch updates
+
+## Observability as Code
+- Dashboards as code: CloudWatch dashboard JSON in IaC
+- Alarms as code: composite alarms, anomaly detection
+- SLO definition: error budget burn rate alerts (fast burn + slow burn)
+- Synthetic canaries: CloudWatch Synthetics for critical user journeys
+- Log retention policies, log group encryption
+
+## Cost & Efficiency
+- Resource tagging: mandatory via SCPs/Tag Policies, allocation by team/env/service
+- Pipeline compute rightsizing, avoid heavy tests on every push
+- Spot instances in CI/CD: interruption handling, checkpoint strategies
+- ECR lifecycle policies, S3 artifact expiration, CloudWatch log retention
+- NAT Gateway costs: $0.045/hr + $0.045/GB — prefer VPC endpoints
+
+## Infrastructure Review Output Format
+Prefixes: **[SECURITY]**, **[RELIABILITY]**, **[SPEED]**, **[COST]**, **[MAINTAINABILITY]**
+Provide specific YAML / Terraform / CDK code for every recommendation.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -39,3 +39,73 @@ These are hard blockers. If a fix would violate any rule, skip it and explain wh
 ## API Gateway
 - NEVER deploy API Gateway without authorization (Cognito, IAM, or Lambda authorizer)
 - NEVER enable API Gateway execute-api endpoint when using custom domains — disable it
+
+
+## Deep Expertise
+
+## AWS Security Depth
+- IAM: least-privilege enforcement, permission boundaries, SCPs, role trust policies,
+  condition keys (aws:SourceIp, aws:PrincipalOrgID, aws:SourceAccount)
+- No `*` actions or resources in production policies
+- Cross-account access: explicit trust with conditions, not implicit
+- KMS CMK vs AWS managed keys — use CMK for sensitive data, envelope encryption
+  for large payloads
+- S3: PublicAccessBlock at account level, not just bucket level
+- Secrets Manager with rotation, SSM Parameter Store SecureString
+- Never store credentials in environment variables displayed in logs
+- TLS everywhere, no weak ciphers, certificate management via ACM
+
+### Network
+- Security groups: deny by default, no 0.0.0.0/0 ingress on sensitive ports
+- NACLs as secondary defense layer
+- VPC Flow Logs enabled on all VPCs
+- PrivateLink vs public endpoints — prefer PrivateLink
+- VPC endpoints over NAT Gateway (cost + security)
+- IMDSv2 with hop limit 2 for containers
+
+### Detection & Monitoring
+- GuardDuty threat intelligence enabled
+- CloudTrail: all regions, management + data events, log file validation
+- Security Hub standards: CIS AWS Foundations, AWS FSBP, PCI DSS
+- AWS Config rules for drift detection
+- ECR image scanning (Inspector enhanced scanning)
+- Container hardening: distroless, non-root, read-only filesystem
+
+## OWASP Top 10 (2021)
+1. **Broken Access Control** — server-side enforcement, deny by default
+2. **Cryptographic Failures** — data classification, TLS everywhere, no weak ciphers
+3. **Injection** — parameterized queries, input validation, WAF rules
+4. **Insecure Design** — threat modeling in design phase
+5. **Security Misconfiguration** — hardening, disable defaults, IaC scanning
+6. **Vulnerable Components** — SBOM, Dependabot, CVE triage
+7. **Authentication Failures** — MFA, session management, brute-force protection
+8. **Software/Data Integrity** — code signing, supply chain, CI integrity
+9. **Logging/Monitoring Failures** — SIEM coverage, alerting SLAs
+10. **SSRF** — IMDSv2, network egress controls
+
+## OWASP Top 10 for LLMs (2025)
+- **LLM01: Prompt Injection** — direct and indirect, sandboxing, input sanitization
+- **LLM02: Sensitive Information Disclosure** — PII in prompts/outputs, output filtering
+- **LLM03: Supply Chain** — model provenance, fine-tune data poisoning
+- **LLM04: Data and Model Poisoning** — training data validation
+- **LLM05: Improper Output Handling** — downstream injection, unsafe deserialization
+- **LLM06: Excessive Agency** — principle of least privilege for agent tool access
+- **LLM07: System Prompt Leakage** — confidentiality of system prompts
+- **LLM08: Vector/Embedding Weaknesses** — RAG poisoning, embedding inversion
+- **LLM09: Misinformation** — hallucination risk in high-stakes domains
+- **LLM10: Unbounded Consumption** — token budget limits, rate limiting, DoS prevention
+
+## Threat Modeling
+- Apply STRIDE: Spoofing, Tampering, Repudiation, Information Disclosure, DoS, Elevation
+- Data flow diagram analysis, trust boundary identification
+- Attack surface enumeration: public endpoints, third-party integrations, IAM paths
+
+## Compliance & Supply Chain
+- SOC 2, ISO 27001, GDPR, HIPAA alignment indicators
+- SBOM generation and dependency confusion attack vectors
+- CI/CD pipeline security: secret scanning, SAST, DAST, IaC scanning (Checkov, cfn-nag)
+
+## Security Review Output Format
+Classify findings: **[CRITICAL]** (exploitable now), **[HIGH]**, **[MEDIUM]**, **[LOW]**
+For each: Finding → Impact → Blast Radius → Remediation → Detective Controls
+Map to OWASP category or AWS security pillar. Flag compliance implications.


### PR DESCRIPTION
## What

Applies the [engineering-team skill](https://github.com/barakcaf/openclaw-skills/tree/main/engineering-team) to RunMapRepeat.

### 3 Role-Based Agents (`.claude/agents/`)

| Agent | Role |
|-------|------|
| **principal-engineer** | Tech lead & orchestrator — routes tasks, handles architecture/backend/infra |
| **security-engineer** | AppSec, IAM, OWASP, threat modeling, compliance |
| **ux-engineer** | Accessibility, performance, design systems, i18n |

All agents have full read/write/edit/bash access. Invoke via Claude Code with `/principal-engineer <task>`.

The principal-engineer acts as orchestrator — it triages incoming tasks and delegates to specialists or runs parallel reviews.

### Deep Expertise Merged into Rules (`.claude/rules/`)

| File | What's new |
|------|-----------|
| `security.md` | +OWASP Top 10, LLM Top 10, STRIDE, compliance, supply chain |
| `frontend.md` | +WCAG 2.2, Core Web Vitals, Nielsen's 10 heuristics, i18n |
| `infrastructure.md` | +CI/CD pipeline design, deployment strategies, cost optimization |
| `code-quality.md` | **NEW** — architecture patterns, AWS service limits, DDD, observability |

Existing project-specific rules preserved at top of each file. Deep expertise appended below.

### No changes to
- CLAUDE.md, .github/prompts/, .github/workflows/
- Any source code