### PR TITLE
feat: [2.5] Toast Component + Provider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { PlannedRunsPage } from "./pages/PlannedRunsPage";
 import { RunDetailPage } from "./pages/RunDetailPage";
 import { ProfilePage } from "./pages/ProfilePage";
 import { ProfileSetupPage } from "./pages/ProfileSetupPage";
+import { ToastProvider } from "./providers/ToastProvider";
 
 function AppRoutes() {
   const location = useLocation();
@@ -94,7 +95,9 @@ function App() {
     <ThemeProvider>
       <BrowserRouter>
         <AuthProvider>
-          <AppRoutes />
+          <ToastProvider>
+            <AppRoutes />
+          </ToastProvider>
         </AuthProvider>
       </BrowserRouter>
     </ThemeProvider>

--- a/frontend/src/__tests__/Toast.test.tsx
+++ b/frontend/src/__tests__/Toast.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ToastProvider, useToast } from "../providers/ToastProvider";
+
+function TestConsumer() {
+  const { show } = useToast();
+  return (
+    <div>
+      <button onClick={() => show({ message: "Success!", variant: "success" })}>
+        Show Success
+      </button>
+      <button onClick={() => show({ message: "Error!", variant: "error" })}>
+        Show Error
+      </button>
+      <button onClick={() => show({ message: "Info!", variant: "info" })}>
+        Show Info
+      </button>
+      <button onClick={() => show({ message: "Quick!", variant: "info", duration: 1000 })}>
+        Show Quick
+      </button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <ToastProvider>
+      <TestConsumer />
+    </ToastProvider>
+  );
+}
+
+describe("Toast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows a toast when triggered", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Success"));
+    });
+
+    expect(screen.getByText("Success!")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses after default duration", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Info"));
+    });
+    expect(screen.getByText("Info!")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(4200);
+    });
+
+    expect(screen.queryByText("Info!")).not.toBeInTheDocument();
+  });
+
+  it("auto-dismisses after custom duration", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Quick"));
+    });
+    expect(screen.getByText("Quick!")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(screen.queryByText("Quick!")).not.toBeInTheDocument();
+  });
+
+  it("dismisses on click", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Success"));
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText("Success!"));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.queryByText("Success!")).not.toBeInTheDocument();
+  });
+
+  it("stacks multiple toasts", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Success"));
+      fireEvent.click(screen.getByText("Show Error"));
+      fireEvent.click(screen.getByText("Show Info"));
+    });
+
+    expect(screen.getByText("Success!")).toBeInTheDocument();
+    expect(screen.getByText("Error!")).toBeInTheDocument();
+    expect(screen.getByText("Info!")).toBeInTheDocument();
+  });
+
+  it("uses role=alert for error variant", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Error"));
+    });
+
+    expect(screen.getByText("Error!")).toHaveAttribute("role", "alert");
+  });
+
+  it("uses role=status for success variant", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Success"));
+    });
+
+    expect(screen.getByText("Success!")).toHaveAttribute("role", "status");
+  });
+
+  it("uses role=status for info variant", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Show Info"));
+    });
+
+    expect(screen.getByText("Info!")).toHaveAttribute("role", "status");
+  });
+
+  it("throws when useToast is used outside provider", () => {
+    function BadConsumer() {
+      useToast();
+      return null;
+    }
+
+    expect(() => render(<BadConsumer />)).toThrow(
+      "useToast must be used within a ToastProvider"
+    );
+  });
+});

--- a/frontend/src/components/ui/Toast.module.css
+++ b/frontend/src/components/ui/Toast.module.css
@@ -1,0 +1,122 @@
+.container {
+  position: fixed;
+  top: var(--space-4);
+  right: var(--space-4);
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  pointer-events: none;
+}
+
+@media (max-width: 640px) {
+  .container {
+    right: var(--space-4);
+    left: var(--space-4);
+    align-items: center;
+  }
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-primary);
+  pointer-events: auto;
+  cursor: pointer;
+  min-width: 280px;
+  max-width: 420px;
+  animation: slideIn var(--duration-normal) var(--ease-out);
+}
+
+.toast.exiting {
+  animation: slideOut var(--duration-normal) var(--ease-in) forwards;
+}
+
+.success {
+  background: var(--color-success-subtle);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.error {
+  background: var(--color-error-subtle);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.info {
+  background: var(--color-secondary-subtle);
+  border-color: var(--color-secondary);
+  color: var(--color-secondary);
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOut {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+}
+
+@media (max-width: 640px) {
+  .toast {
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  @keyframes slideIn {
+    from {
+      opacity: 0;
+      transform: translateY(-100%);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes slideOut {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-100%);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
+  }
+
+  .toast.exiting {
+    animation: none;
+    opacity: 0;
+  }
+}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,28 @@
+import { createPortal } from "react-dom";
+import type { ToastItem } from "../../providers/ToastProvider";
+import styles from "./Toast.module.css";
+
+interface ToastContainerProps {
+  toasts: ToastItem[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
+  if (toasts.length === 0) return null;
+
+  return createPortal(
+    <div className={styles.container}>
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={`${styles.toast} ${styles[toast.variant]}${toast.exiting ? ` ${styles.exiting}` : ""}`}
+          role={toast.variant === "error" ? "alert" : "status"}
+          onClick={() => onDismiss(toast.id)}
+        >
+          {toast.message}
+        </div>
+      ))}
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/providers/ToastProvider.tsx
+++ b/frontend/src/providers/ToastProvider.tsx
@@ -1,0 +1,81 @@
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { ToastContainer } from "../components/ui/Toast";
+
+type ToastVariant = "success" | "error" | "info";
+
+export interface ToastItem {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+  exiting?: boolean;
+}
+
+interface ShowToastOptions {
+  message: string;
+  variant?: ToastVariant;
+  duration?: number;
+}
+
+interface ToastContextValue {
+  show: (options: ShowToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const DEFAULT_DURATION = 4000;
+const EXIT_ANIMATION_MS = 200;
+
+let toastCounter = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+
+    setToasts((prev) => prev.map((t) => (t.id === id ? { ...t, exiting: true } : t)));
+
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, EXIT_ANIMATION_MS);
+  }, []);
+
+  const show = useCallback(
+    ({ message, variant = "info", duration = DEFAULT_DURATION }: ShowToastOptions) => {
+      const id = `toast-${++toastCounter}`;
+      const toast: ToastItem = { id, message, variant };
+
+      setToasts((prev) => [...prev, toast]);
+
+      const timer = setTimeout(() => {
+        timersRef.current.delete(id);
+        dismiss(id);
+      }, duration);
+      timersRef.current.set(id, timer);
+    },
+    [dismiss]
+  );
+
+  const value = useMemo(() => ({ show }), [show]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- Created `Toast.tsx` + `Toast.module.css` UI component rendered in a portal
- Created `ToastProvider.tsx` with `useToast()` hook exposing `show({ message, variant, duration })`
- Wired `ToastProvider` into `App.tsx` wrapping all routes

## Details
- **Variants:** success, error, info — each with semantic design token colors
- **Positioning:** top-right on desktop, top-center on mobile (responsive)
- **Auto-dismiss:** configurable duration (default 4000ms)
- **Stacking:** multiple toasts stack vertically with gap
- **Accessibility:** `role=status` for info/success, `role=alert` for error
- **Reduced motion:** `@media (prefers-reduced-motion: reduce)` disables animations
- **Design tokens:** uses `--color-*`, `--space-*`, `--radius-*`, `--shadow-*`, `--z-toast`, `--duration-*`, `--ease-*` from tokens.css

## Test plan
- [x] 9 unit tests passing: show/hide, auto-dismiss (default + custom), click dismiss, stacking, role=alert for error, role=status for success/info, throws outside provider
- [x] TypeScript compiles clean (`tsc --noEmit`)

Closes #129

Generated with [Claude Code](https://claude.com/claude-code)