### PR TITLE
fix: vitest-axe import path for TS build

### DIFF
--- a/frontend/src/__tests__/Divider.test.tsx
+++ b/frontend/src/__tests__/Divider.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { axe } from "vitest-axe";
-import { toHaveNoViolations } from "vitest-axe/matchers";
+import { toHaveNoViolations } from "vitest-axe/dist/matchers";
 import { Divider } from "../components/ui/Divider";
 
 expect.extend({ toHaveNoViolations });

--- a/frontend/src/__tests__/PageHeader.test.tsx
+++ b/frontend/src/__tests__/PageHeader.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { axe } from "vitest-axe";
-import { toHaveNoViolations } from "vitest-axe/matchers";
+import { toHaveNoViolations } from "vitest-axe/dist/matchers";
 import { PageHeader } from "../components/ui/PageHeader";
 
 expect.extend({ toHaveNoViolations });

--- a/frontend/src/__tests__/SegmentedControl.test.tsx
+++ b/frontend/src/__tests__/SegmentedControl.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { axe } from "vitest-axe";
-import { toHaveNoViolations } from "vitest-axe/matchers";
+import { toHaveNoViolations } from "vitest-axe/dist/matchers";
 import { SegmentedControl } from "../components/ui/SegmentedControl";
 
 expect.extend({ toHaveNoViolations });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,4 +1,4 @@
 import "@testing-library/jest-dom/vitest";
-import { toHaveNoViolations } from "vitest-axe/matchers";
+import { toHaveNoViolations } from "vitest-axe/dist/matchers";
 
 expect.extend(toHaveNoViolations);


### PR DESCRIPTION
Fixes pipeline failure — `vitest-axe/matchers` root re-export uses `export type *` which causes TS1362 at build time. Import from `vitest-axe/dist/matchers` instead.

Affected files: Divider, PageHeader, SegmentedControl tests + vitest.setup.ts