### PR TITLE
fix: duplicate notifications + auto-fix permission denials

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -56,7 +56,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           use_bedrock: "true"
-          claude_args: "--model arn:aws:bedrock:us-east-1:579083551251:application-inference-profile/jk8gcjrpuokf --max-turns 30"
+          claude_args: "--model arn:aws:bedrock:us-east-1:579083551251:application-inference-profile/jk8gcjrpuokf --max-turns 30 --permission-mode bypassPermissions"
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude"
           allowed_bots: "runmaprepeat-autofix[bot],github-actions[bot]"

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -8,7 +8,11 @@ jobs:
   notify:
     name: Notify on PR Review
     runs-on: ubuntu-latest
-    if: github.event.review.user.login != github.event.pull_request.user.login
+    # Only notify for human reviews — bot reviews (AI code review) have their own
+    # notification in pr-review.yml. This prevents duplicate Telegram messages.
+    if: >
+      github.event.review.user.login != github.event.pull_request.user.login &&
+      github.event.review.user.type != 'Bot'
     steps:
       - name: Send notification
         uses: actions/github-script@v7


### PR DESCRIPTION
Two fixes:

1. **Duplicate Telegram notifications** — `pr-notify.yml` now skips bot reviews (`user.type != 'Bot'`). AI reviews already have their own notification in `pr-review.yml`, so bot review events were causing duplicates.

2. **Auto-fix can't edit files** — Claude Code was getting 15 permission denials because the default tool permissions for `issue_comment` events don't include Write/Edit. Added `--permission-mode bypassPermissions` to `claude_args` so it can actually modify code during fix cycles.