### PR TITLE
fix: checkout PR branch in claude-fix workflow

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -44,11 +44,25 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Get PR head ref
+        id: pr-ref
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            core.setOutput('ref', pr.head.ref);
+
       - name: Checkout PR branch
         id: checkout
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ steps.pr-ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Run Claude Code


### PR DESCRIPTION
## Problem

`issue_comment` events don't carry a git ref. `actions/checkout@v4` defaults to checking out **main** — not the PR branch. Claude Code then tries `git show` on files that only exist on the PR branch:

```
fatal: could not open 'frontend/src/components/ui/Button.tsx' for reading: No such file or directory
```

This caused **every auto-fix run on #167 to crash** (4 errors across multiple cycles).

## Fix

Added a step before checkout that resolves the PR head ref via the GitHub API, then passes it as `ref:` to `actions/checkout`.

## Impact

All future auto-fix runs will correctly check out the PR branch instead of main.